### PR TITLE
IBX-538: Aligned codebase with rebranded ibexa/core

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /vendor
 /.php_cs.cache
+/composer.lock

--- a/composer.json
+++ b/composer.json
@@ -8,19 +8,19 @@
     },
     "autoload": {
         "psr-4": {
-            "EzSystems\\EzPlatformRestBundle\\": "src/bundle/",
-            "EzSystems\\EzPlatformRest\\": "src/lib/",
             "Ibexa\\Bundle\\Rest\\": "src/bundle/",
             "Ibexa\\Rest\\": "src/lib/",
-            "Ibexa\\Contracts\\Rest\\": "src/contracts/"
+            "Ibexa\\Contracts\\Rest\\": "src/contracts/",
+            "EzSystems\\EzPlatformRestBundle\\": "src/bundle/",
+            "EzSystems\\EzPlatformRest\\": "src/lib/"
         }
     },
     "autoload-dev": {
         "psr-4": {
-            "EzSystems\\EzPlatformRestBundle\\Tests\\": "tests/bundle/",
-            "EzSystems\\EzPlatformRest\\Tests\\": "tests/lib/",
             "Ibexa\\Tests\\Rest\\": "tests/lib/",
-            "Ibexa\\Tests\\Bundle\\Rest\\": "tests/bundle/"
+            "Ibexa\\Tests\\Bundle\\Rest\\": "tests/bundle/",
+            "EzSystems\\EzPlatformRestBundle\\Tests\\": "tests/bundle/",
+            "EzSystems\\EzPlatformRest\\Tests\\": "tests/lib/"
         }
     },
     "require": {

--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,7 @@
         "ext-libxml": "*",
         "ext-simplexml": "*",
         "ext-xmlwriter": "*",
-        "ezsystems/ezplatform-kernel": "^4.0@dev",
+        "ibexa/core": "^4.0@dev",
         "symfony/http-kernel": "^5.3",
         "symfony/dependency-injection": "^5.3",
         "symfony/routing": "^5.3",

--- a/src/bundle/Resources/config/input_parsers.yml
+++ b/src/bundle/Resources/config/input_parsers.yml
@@ -575,7 +575,7 @@ services:
         class: '%ezpublish_rest.input.parser.internal.sortclause.data_key_value_object.class%'
         arguments:
             - 'ContentId'
-            - 'eZ\Publish\API\Repository\Values\Content\Query\SortClause\ContentId'
+            - 'Ibexa\Contracts\Core\Repository\Values\Content\Query\SortClause\ContentId'
         tags:
             - { name: ezpublish_rest.input.parser, mediaType: application/vnd.ez.api.internal.sortclause.ContentId }
 
@@ -584,7 +584,7 @@ services:
         class: '%ezpublish_rest.input.parser.internal.sortclause.data_key_value_object.class%'
         arguments:
             - 'ContentName'
-            - 'eZ\Publish\API\Repository\Values\Content\Query\SortClause\ContentName'
+            - 'Ibexa\Contracts\Core\Repository\Values\Content\Query\SortClause\ContentName'
         tags:
             - { name: ezpublish_rest.input.parser, mediaType: application/vnd.ez.api.internal.sortclause.ContentName }
 
@@ -593,7 +593,7 @@ services:
         class: '%ezpublish_rest.input.parser.internal.sortclause.data_key_value_object.class%'
         arguments:
             - 'DateModified'
-            - 'eZ\Publish\API\Repository\Values\Content\Query\SortClause\DateModified'
+            - 'Ibexa\Contracts\Core\Repository\Values\Content\Query\SortClause\DateModified'
         tags:
             - { name: ezpublish_rest.input.parser, mediaType: application/vnd.ez.api.internal.sortclause.DateModified }
 
@@ -602,7 +602,7 @@ services:
         class: '%ezpublish_rest.input.parser.internal.sortclause.data_key_value_object.class%'
         arguments:
             - 'DatePublished'
-            - 'eZ\Publish\API\Repository\Values\Content\Query\SortClause\DatePublished'
+            - 'Ibexa\Contracts\Core\Repository\Values\Content\Query\SortClause\DatePublished'
         tags:
             - { name: ezpublish_rest.input.parser, mediaType: application/vnd.ez.api.internal.sortclause.DatePublished }
 
@@ -611,7 +611,7 @@ services:
         class: '%ezpublish_rest.input.parser.internal.sortclause.data_key_value_object.class%'
         arguments:
             - 'LocationDepth'
-            - 'eZ\Publish\API\Repository\Values\Content\Query\SortClause\Location\Depth'
+            - 'Ibexa\Contracts\Core\Repository\Values\Content\Query\SortClause\Location\Depth'
         tags:
             - { name: ezpublish_rest.input.parser, mediaType: application/vnd.ez.api.internal.sortclause.LocationDepth }
 
@@ -620,7 +620,7 @@ services:
         class: '%ezpublish_rest.input.parser.internal.sortclause.data_key_value_object.class%'
         arguments:
             - 'LocationPath'
-            - 'eZ\Publish\API\Repository\Values\Content\Query\SortClause\Location\Path'
+            - 'Ibexa\Contracts\Core\Repository\Values\Content\Query\SortClause\Location\Path'
         tags:
             - { name: ezpublish_rest.input.parser, mediaType: application/vnd.ez.api.internal.sortclause.LocationPath }
 
@@ -629,7 +629,7 @@ services:
         class: '%ezpublish_rest.input.parser.internal.sortclause.data_key_value_object.class%'
         arguments:
             - 'LocationPriority'
-            - 'eZ\Publish\API\Repository\Values\Content\Query\SortClause\Location\Priority'
+            - 'Ibexa\Contracts\Core\Repository\Values\Content\Query\SortClause\Location\Priority'
         tags:
             - { name: ezpublish_rest.input.parser, mediaType: application/vnd.ez.api.internal.sortclause.LocationPriority }
 
@@ -638,7 +638,7 @@ services:
         class: '%ezpublish_rest.input.parser.internal.sortclause.data_key_value_object.class%'
         arguments:
             - 'LocationId'
-            - 'eZ\Publish\API\Repository\Values\Content\Query\SortClause\Location\Id'
+            - 'Ibexa\Contracts\Core\Repository\Values\Content\Query\SortClause\Location\Id'
         tags:
             - { name: ezpublish_rest.input.parser, mediaType: application/vnd.ez.api.internal.sortclause.LocationId }
 
@@ -647,7 +647,7 @@ services:
         class: '%ezpublish_rest.input.parser.internal.sortclause.data_key_value_object.class%'
         arguments:
             - 'SectionIdentifier'
-            - 'eZ\Publish\API\Repository\Values\Content\Query\SortClause\SectionIdentifier'
+            - 'Ibexa\Contracts\Core\Repository\Values\Content\Query\SortClause\SectionIdentifier'
         tags:
             - { name: ezpublish_rest.input.parser, mediaType: application/vnd.ez.api.internal.sortclause.SectionIdentifier }
 
@@ -656,7 +656,7 @@ services:
         class: '%ezpublish_rest.input.parser.internal.sortclause.data_key_value_object.class%'
         arguments:
             - 'SectionName'
-            - 'eZ\Publish\API\Repository\Values\Content\Query\SortClause\SectionName'
+            - 'Ibexa\Contracts\Core\Repository\Values\Content\Query\SortClause\SectionName'
         tags:
             - { name: ezpublish_rest.input.parser, mediaType: application/vnd.ez.api.internal.sortclause.SectionName }
 
@@ -665,7 +665,7 @@ services:
         class: 'Ibexa\Rest\Server\Input\Parser\SortClause\DataKeyValueObjectClass'
         arguments:
             - 'Score'
-            - 'eZ\Publish\API\Repository\Values\Content\Query\SortClause\Score'
+            - 'Ibexa\Contracts\Core\Repository\Values\Content\Query\SortClause\Score'
         tags:
             - { name: ezpublish_rest.input.parser, mediaType: application/vnd.ez.api.internal.sortclause.Score }
 
@@ -880,7 +880,7 @@ services:
             - { name: ezpublish_rest.input.parser, mediaType: application/vnd.ez.api.internal.limitation.Subtree }
         arguments:
             - 'locationPath'
-            - 'eZ\Publish\API\Repository\Values\User\Limitation\SubtreeLimitation'
+            - 'Ibexa\Contracts\Core\Repository\Values\User\Limitation\SubtreeLimitation'
 
     ezpublish_rest.input.parser.internal.limitation.Section:
         parent: ezpublish_rest.input.parser
@@ -889,4 +889,4 @@ services:
             - { name: ezpublish_rest.input.parser, mediaType: application/vnd.ez.api.internal.limitation.Section }
         arguments:
             - 'sectionId'
-            - 'eZ\Publish\API\Repository\Values\User\Limitation\SectionLimitation'
+            - 'Ibexa\Contracts\Core\Repository\Values\User\Limitation\SectionLimitation'

--- a/src/bundle/Resources/config/security.yml
+++ b/src/bundle/Resources/config/security.yml
@@ -32,6 +32,6 @@ services:
 
     Ibexa\Rest\Server\Security\EventListener\SecurityListener:
         arguments:
-            - '@eZ\Publish\API\Repository\PermissionResolver'
+            - '@Ibexa\Contracts\Core\Repository\PermissionResolver'
         tags:
             - { name: kernel.event_subscriber }

--- a/src/bundle/Resources/config/services.yml
+++ b/src/bundle/Resources/config/services.yml
@@ -214,7 +214,7 @@ services:
             - "@ezpublish.api.service.location"
             - "@ezpublish.api.service.section"
             - "@ezpublish.api.repository"
-            - '@eZ\Publish\API\Repository\PermissionResolver'
+            - '@Ibexa\Contracts\Core\Repository\PermissionResolver'
         tags: [controller.service_arguments]
 
     ezpublish_rest.controller.url_wildcard:
@@ -244,7 +244,7 @@ services:
         parent: ezpublish_rest.controller.base
         arguments:
             - "%ezpublish_rest.csrf_token_intention%"
-            - '@eZ\Publish\API\Repository\PermissionResolver'
+            - '@Ibexa\Contracts\Core\Repository\PermissionResolver'
             - '@ezpublish.api.service.user'
             - "@?ezpublish_rest.session_authenticator"
             - "@?ezpublish_rest.security.csrf.token_manager"
@@ -450,7 +450,7 @@ services:
             - { name: ezpublish_rest.input.handler, format: xml }
 
     ezpublish_rest.templated_router:
-        class: eZ\Bundle\EzPublishCoreBundle\Routing\DefaultRouter
+        class: Ibexa\Bundle\Core\Routing\DefaultRouter
         parent: hautelook.router.template
         calls:
             - [ setOption, [ strict_requirements, ~ ] ]

--- a/src/bundle/Resources/config/services.yml
+++ b/src/bundle/Resources/config/services.yml
@@ -428,7 +428,7 @@ services:
     ezpublish_rest.output.value_object_visitor.Exception.InvalidArgumentException:
         class: "%ezpublish_rest.output.value_object_visitor.Exception.InvalidArgumentException.class%"
         tags:
-            - { name: ezpublish_rest.output.value_object_visitor, type: \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException }
+            - { name: ezpublish_rest.output.value_object_visitor, type: \Ibexa\Contracts\Core\Repository\Exceptions\InvalidArgumentException }
 
     ezpublish_rest.input.dispatcher:
         class: "%ezpublish_rest.input.dispatcher.class%"

--- a/src/bundle/Resources/config/value_object_visitors.yml
+++ b/src/bundle/Resources/config/value_object_visitors.yml
@@ -140,28 +140,28 @@ services:
         class: "%ezpublish_rest.output.value_object_visitor.InvalidArgumentException.class%"
         arguments: [ "%kernel.debug%", "@translator" ]
         tags:
-            - { name: ezpublish_rest.output.value_object_visitor, type: eZ\Publish\API\Repository\Exceptions\InvalidArgumentException }
+            - { name: ezpublish_rest.output.value_object_visitor, type: Ibexa\Contracts\Core\Repository\Exceptions\InvalidArgumentException }
 
     ezpublish_rest.output.value_object_visitor.NotFoundException:
         parent: ezpublish_rest.output.value_object_visitor.base
         class: "%ezpublish_rest.output.value_object_visitor.NotFoundException.class%"
         arguments: [ "%kernel.debug%", "@translator" ]
         tags:
-            - { name: ezpublish_rest.output.value_object_visitor, type: eZ\Publish\API\Repository\Exceptions\NotFoundException }
+            - { name: ezpublish_rest.output.value_object_visitor, type: Ibexa\Contracts\Core\Repository\Exceptions\NotFoundException }
 
     ezpublish_rest.output.value_object_visitor.UnauthorizedException:
         parent: ezpublish_rest.output.value_object_visitor.base
         class: "%ezpublish_rest.output.value_object_visitor.UnauthorizedException.class%"
         arguments: [ "%kernel.debug%", "@translator" ]
         tags:
-            - { name: ezpublish_rest.output.value_object_visitor, type: eZ\Publish\API\Repository\Exceptions\UnauthorizedException }
+            - { name: ezpublish_rest.output.value_object_visitor, type: Ibexa\Contracts\Core\Repository\Exceptions\UnauthorizedException }
 
     ezpublish_rest.output.value_object_visitor.BadStateException:
         parent: ezpublish_rest.output.value_object_visitor.base
         class: "%ezpublish_rest.output.value_object_visitor.BadStateException.class%"
         arguments: [ "%kernel.debug%", "@translator" ]
         tags:
-            - { name: ezpublish_rest.output.value_object_visitor, type: eZ\Publish\API\Repository\Exceptions\BadStateException }
+            - { name: ezpublish_rest.output.value_object_visitor, type: Ibexa\Contracts\Core\Repository\Exceptions\BadStateException }
 
     ezpublish_rest.output.value_object_visitor.BadRequestException:
         parent: ezpublish_rest.output.value_object_visitor.base
@@ -190,7 +190,7 @@ services:
         class: "%ezpublish_rest.output.value_object_visitor.NotImplementedException.class%"
         arguments: [ "%kernel.debug%", "@translator" ]
         tags:
-            - { name: ezpublish_rest.output.value_object_visitor, type: eZ\Publish\API\Repository\Exceptions\NotImplementedException }
+            - { name: ezpublish_rest.output.value_object_visitor, type: Ibexa\Contracts\Core\Repository\Exceptions\NotImplementedException }
 
     ezpublish_rest.output.value_object_visitor.Exception:
         parent: ezpublish_rest.output.value_object_visitor.base
@@ -210,7 +210,7 @@ services:
         parent: ezpublish_rest.output.value_object_visitor.base
         class: Ibexa\Rest\Server\Output\ValueObjectVisitor\Language
         tags:
-            - { name: ezpublish_rest.output.value_object_visitor, type: eZ\Publish\API\Repository\Values\Content\Language }
+            - { name: ezpublish_rest.output.value_object_visitor, type: Ibexa\Contracts\Core\Repository\Values\Content\Language }
 
     # Section
     ezpublish_rest.output.value_object_visitor.SectionList:
@@ -229,7 +229,7 @@ services:
         parent: ezpublish_rest.output.value_object_visitor.base
         class: "%ezpublish_rest.output.value_object_visitor.Section.class%"
         tags:
-            - { name: ezpublish_rest.output.value_object_visitor, type: eZ\Publish\API\Repository\Values\Content\Section }
+            - { name: ezpublish_rest.output.value_object_visitor, type: Ibexa\Contracts\Core\Repository\Values\Content\Section }
 
     # URLWildcard
     ezpublish_rest.output.value_object_visitor.URLWildcardList:
@@ -242,7 +242,7 @@ services:
         parent: ezpublish_rest.output.value_object_visitor.base
         class: "%ezpublish_rest.output.value_object_visitor.URLWildcard.class%"
         tags:
-            - { name: ezpublish_rest.output.value_object_visitor, type: eZ\Publish\API\Repository\Values\Content\URLWildcard }
+            - { name: ezpublish_rest.output.value_object_visitor, type: Ibexa\Contracts\Core\Repository\Values\Content\URLWildcard }
 
     ezpublish_rest.output.value_object_visitor.CreatedURLWildcard:
         parent: ezpublish_rest.output.value_object_visitor.base
@@ -267,7 +267,7 @@ services:
         parent: ezpublish_rest.output.value_object_visitor.base
         class: "%ezpublish_rest.output.value_object_visitor.URLAlias.class%"
         tags:
-            - { name: ezpublish_rest.output.value_object_visitor, type: eZ\Publish\API\Repository\Values\Content\URLAlias }
+            - { name: ezpublish_rest.output.value_object_visitor, type: Ibexa\Contracts\Core\Repository\Values\Content\URLAlias }
 
     ezpublish_rest.output.value_object_visitor.CreatedURLAlias:
         parent: ezpublish_rest.output.value_object_visitor.base
@@ -280,7 +280,7 @@ services:
         parent: ezpublish_rest.output.value_object_visitor.base
         class: Ibexa\Rest\Server\Output\ValueObjectVisitor\Author
         tags:
-            - { name: ezpublish_rest.output.value_object_visitor, type: eZ\Publish\Core\FieldType\Author\Author }
+            - { name: ezpublish_rest.output.value_object_visitor, type: Ibexa\Core\FieldType\Author\Author }
 
     ezpublish_rest.output.value_object_visitor.ContentList:
         parent: ezpublish_rest.output.value_object_visitor.base
@@ -319,13 +319,13 @@ services:
         parent: ezpublish_rest.output.value_object_visitor.base
         class: "%ezpublish_rest.output.value_object_visitor.VersionInfo.class%"
         tags:
-            - { name: ezpublish_rest.output.value_object_visitor, type: eZ\Publish\API\Repository\Values\Content\VersionInfo }
+            - { name: ezpublish_rest.output.value_object_visitor, type: Ibexa\Contracts\Core\Repository\Values\Content\VersionInfo }
 
     ezpublish_rest.output.value_object_visitor.ImageVariation:
         parent: ezpublish_rest.output.value_object_visitor.base
         class: "%ezpublish_rest.output.value_object_visitor.ImageVariation.class%"
         tags:
-            - { name: ezpublish_rest.output.value_object_visitor, type: eZ\Publish\SPI\Variation\Values\ImageVariation }
+            - { name: ezpublish_rest.output.value_object_visitor, type: Ibexa\Contracts\Core\Variation\Values\ImageVariation }
 
     ezpublish_rest.output.value_object_visitor.Version:
         parent: ezpublish_rest.output.value_object_visitor.base
@@ -347,7 +347,7 @@ services:
         arguments:
             $contentService: '@ezpublish.api.service.content'
         tags:
-            - { name: ezpublish_rest.output.value_object_visitor, type: eZ\Publish\API\Repository\Values\User\UserGroup }
+            - { name: ezpublish_rest.output.value_object_visitor, type: Ibexa\Contracts\Core\Repository\Values\User\UserGroup }
 
     ezpublish_rest.output.value_object_visitor.RestUserGroup:
         parent: ezpublish_rest.output.value_object_visitor.base
@@ -398,7 +398,7 @@ services:
         arguments:
             $contentService: '@ezpublish.api.service.content'
         tags:
-            - { name: ezpublish_rest.output.value_object_visitor, type: eZ\Publish\API\Repository\Values\User\User }
+            - { name: ezpublish_rest.output.value_object_visitor, type: Ibexa\Contracts\Core\Repository\Values\User\User }
 
     ezpublish_rest.output.value_object_visitor.RestUser:
         parent: ezpublish_rest.output.value_object_visitor.base
@@ -428,7 +428,7 @@ services:
         parent: ezpublish_rest.output.value_object_visitor.base
         class: Ibexa\Rest\Server\Output\ValueObjectVisitor\ContentType
         tags:
-            - { name: ezpublish_rest.output.value_object_visitor, type: eZ\Publish\API\Repository\Values\ContentType\ContentType }
+            - { name: ezpublish_rest.output.value_object_visitor, type: Ibexa\Contracts\Core\Repository\Values\ContentType\ContentType }
 
     ezpublish_rest.output.value_object_visitor.RestContentType:
         parent: ezpublish_rest.output.value_object_visitor.base
@@ -458,7 +458,7 @@ services:
         parent: ezpublish_rest.output.value_object_visitor.base
         class: "%ezpublish_rest.output.value_object_visitor.ContentTypeGroup.class%"
         tags:
-            - { name: ezpublish_rest.output.value_object_visitor, type: eZ\Publish\API\Repository\Values\ContentType\ContentTypeGroup }
+            - { name: ezpublish_rest.output.value_object_visitor, type: Ibexa\Contracts\Core\Repository\Values\ContentType\ContentTypeGroup }
 
     ezpublish_rest.output.value_object_visitor.CreatedContentTypeGroup:
         parent: ezpublish_rest.output.value_object_visitor.base
@@ -540,15 +540,15 @@ services:
         parent: ezpublish_rest.output.value_object_visitor.base
         class: "%ezpublish_rest.output.value_object_visitor.Role.class%"
         tags:
-            - { name: ezpublish_rest.output.value_object_visitor, type: eZ\Publish\API\Repository\Values\User\Role }
-            - { name: ezpublish_rest.output.value_object_visitor, type: eZ\Publish\API\Repository\Values\User\RoleDraft }
+            - { name: ezpublish_rest.output.value_object_visitor, type: Ibexa\Contracts\Core\Repository\Values\User\Role }
+            - { name: ezpublish_rest.output.value_object_visitor, type: Ibexa\Contracts\Core\Repository\Values\User\RoleDraft }
 
     ezpublish_rest.output.value_object_visitor.Policy:
         parent: ezpublish_rest.output.value_object_visitor.base
         class: "%ezpublish_rest.output.value_object_visitor.Policy.class%"
         tags:
-            - { name: ezpublish_rest.output.value_object_visitor, type: eZ\Publish\API\Repository\Values\User\Policy }
-            - { name: ezpublish_rest.output.value_object_visitor, type: eZ\Publish\API\Repository\Values\User\PolicyDraft }
+            - { name: ezpublish_rest.output.value_object_visitor, type: Ibexa\Contracts\Core\Repository\Values\User\Policy }
+            - { name: ezpublish_rest.output.value_object_visitor, type: Ibexa\Contracts\Core\Repository\Values\User\PolicyDraft }
 
     ezpublish_rest.output.value_object_visitor.CreatedPolicy:
         parent: ezpublish_rest.output.value_object_visitor.base
@@ -597,7 +597,7 @@ services:
         parent: ezpublish_rest.output.value_object_visitor.base
         class: "%ezpublish_rest.output.value_object_visitor.Location.class%"
         tags:
-            - { name: ezpublish_rest.output.value_object_visitor, type: eZ\Publish\API\Repository\Values\Content\Location }
+            - { name: ezpublish_rest.output.value_object_visitor, type: Ibexa\Contracts\Core\Repository\Values\Content\Location }
         arguments: ["@ezpublish.api.service.location"]
 
     ezpublish_rest.output.value_object_visitor.LocationList:
@@ -633,38 +633,38 @@ services:
         parent: ezpublish_rest.output.value_object_visitor.base
         class: Ibexa\Rest\Server\Output\ValueObjectVisitor\Range
         tags:
-            - { name: ezpublish_rest.output.value_object_visitor, type: eZ\Publish\API\Repository\Values\Content\Query\Aggregation\Range }
+            - { name: ezpublish_rest.output.value_object_visitor, type: Ibexa\Contracts\Core\Repository\Values\Content\Query\Aggregation\Range }
 
     ezpublish_rest.output.value_object_visitor.RangeAggregationResult:
         parent: ezpublish_rest.output.value_object_visitor.base
         class: Ibexa\Rest\Server\Output\ValueObjectVisitor\RangeAggregationResult
         tags:
-            - { name: ezpublish_rest.output.value_object_visitor, type: eZ\Publish\API\Repository\Values\Content\Search\AggregationResult\RangeAggregationResult }
+            - { name: ezpublish_rest.output.value_object_visitor, type: Ibexa\Contracts\Core\Repository\Values\Content\Search\AggregationResult\RangeAggregationResult }
 
     ezpublish_rest.output.value_object_visitor.StatsAggregationResult:
         parent: ezpublish_rest.output.value_object_visitor.base
         class: Ibexa\Rest\Server\Output\ValueObjectVisitor\StatsAggregationResult
         tags:
-            - { name: ezpublish_rest.output.value_object_visitor, type: eZ\Publish\API\Repository\Values\Content\Search\AggregationResult\StatsAggregationResult }
+            - { name: ezpublish_rest.output.value_object_visitor, type: Ibexa\Contracts\Core\Repository\Values\Content\Search\AggregationResult\StatsAggregationResult }
 
     ezpublish_rest.output.value_object_visitor.TermAggregationResult:
         parent: ezpublish_rest.output.value_object_visitor.base
         class: Ibexa\Rest\Server\Output\ValueObjectVisitor\TermAggregationResult
         tags:
-            - { name: ezpublish_rest.output.value_object_visitor, type: eZ\Publish\API\Repository\Values\Content\Search\AggregationResult\TermAggregationResult }
+            - { name: ezpublish_rest.output.value_object_visitor, type: Ibexa\Contracts\Core\Repository\Values\Content\Search\AggregationResult\TermAggregationResult }
 
     # Object state
     ezpublish_rest.output.value_object_visitor.ObjectState:
         parent: ezpublish_rest.output.value_object_visitor.base
         class: Ibexa\Rest\Server\Output\ValueObjectVisitor\ObjectState
         tags:
-            - { name: ezpublish_rest.output.value_object_visitor, type: eZ\Publish\API\Repository\Values\ObjectState\ObjectState }
+            - { name: ezpublish_rest.output.value_object_visitor, type: Ibexa\Contracts\Core\Repository\Values\ObjectState\ObjectState }
 
     ezpublish_rest.output.value_object_visitor.ObjectStateGroup:
         parent: ezpublish_rest.output.value_object_visitor.base
         class: "%ezpublish_rest.output.value_object_visitor.ObjectStateGroup.class%"
         tags:
-            - { name: ezpublish_rest.output.value_object_visitor, type: eZ\Publish\API\Repository\Values\ObjectState\ObjectStateGroup }
+            - { name: ezpublish_rest.output.value_object_visitor, type: Ibexa\Contracts\Core\Repository\Values\ObjectState\ObjectStateGroup }
 
     ezpublish_rest.output.value_object_visitor.CreatedObjectStateGroup:
         parent: ezpublish_rest.output.value_object_visitor.base


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [IBX-538](https://jira.ez.no/browse/IBX-538)
| **Type**| bug
| **Target version** | Ibexa 4.0
| **BC breaks**      | no
| **Doc needed**     | no

There are some cases which BC layer (ibexa/namespace-compatibility) does not handle yet, so for now performed partial cross-rebranding for already discovered issues.

### Changelist

- [x] [Composer] Required rebranded ibexa/core
- [x] [Composer][DX] Moved current namespace prefixes to the top of autoloader
- [x] Aligned Value Object Visitor DIC with core changes
- [x] Aligned Input Parsers DIC with core changes
- [x] Aligned DIC services with core changes

