### PR TITLE
IBX-1589: Renamed Extension ez_publish_rest to ibexa_rest

### DIFF
--- a/src/bundle/DependencyInjection/Configuration.php
+++ b/src/bundle/DependencyInjection/Configuration.php
@@ -13,7 +13,7 @@ class Configuration extends SiteAccessConfiguration
 {
     public function getConfigTreeBuilder()
     {
-        $treeBuilder = new TreeBuilder('ez_publish_rest');
+        $treeBuilder = new TreeBuilder(IbexaRestExtension::EXTENSION_NAME);
 
         $this->addRestRootResourcesSection($treeBuilder->getRootNode());
 

--- a/src/bundle/DependencyInjection/IbexaRestExtension.php
+++ b/src/bundle/DependencyInjection/IbexaRestExtension.php
@@ -22,6 +22,13 @@ use Symfony\Component\Yaml\Yaml;
  */
 class IbexaRestExtension extends Extension implements PrependExtensionInterface
 {
+    public const EXTENSION_NAME = 'ibexa_rest';
+
+    public function getAlias(): string
+    {
+        return self::EXTENSION_NAME;
+    }
+
     /**
      * {@inheritdoc}
      */


### PR DESCRIPTION
| Question                                  | Answer
| ---------------------------------------- | ------------------
| **JIRA issue**                          | [IBX-1589](https://issues.ibexa.co/browse/IBX-1589)
| **Type**                                   | feature
| **Target Ibexa version** | `v4.0`
| **BC breaks**                          | yes, requires ibexa/compatibility-layer#5

- [x] 23510a6 IBX-1589: Renamed Extension ez_publish_rest to ibexa_rest

#### Checklist:
- [x] Provided PR description.
- [x] Tested the solution manually.
- ~Provided automated test coverage.~ // full stack Behat coverage
- [ ] Ran PHP CS Fixer for new PHP code (use `$ composer fix-cs`).
- [ ] Asked for a review
