### PR TITLE
[Tests] Fixed incorrect import of Content Contract namespace

### DIFF
--- a/tests/lib/Server/Input/Parser/Criterion/LogicalAndTest.php
+++ b/tests/lib/Server/Input/Parser/Criterion/LogicalAndTest.php
@@ -6,9 +6,9 @@
  */
 namespace Ibexa\Tests\Rest\Server\Input\Parser\Criterion;
 
+use Ibexa\Contracts\Core\Repository\Values\Content;
 use Ibexa\Contracts\Rest\Exceptions\Parser as ParserException;
 use Ibexa\Contracts\Rest\Input\ParsingDispatcher;
-use Ibexa\Core\Repository\Values\Content;
 use Ibexa\Rest\Server\Input\Parser;
 use Ibexa\Tests\Rest\Server\Input\Parser\BaseTest;
 

--- a/tests/lib/Server/Input/Parser/Criterion/LogicalOrTest.php
+++ b/tests/lib/Server/Input/Parser/Criterion/LogicalOrTest.php
@@ -6,9 +6,9 @@
  */
 namespace Ibexa\Tests\Rest\Server\Input\Parser\Criterion;
 
+use Ibexa\Contracts\Core\Repository\Values\Content;
 use Ibexa\Contracts\Rest\Exceptions\Parser as ParserException;
 use Ibexa\Contracts\Rest\Input\ParsingDispatcher;
-use Ibexa\Core\Repository\Values\Content;
 use Ibexa\Rest\Server\Input\Parser;
 use Ibexa\Tests\Rest\Server\Input\Parser\BaseTest;
 

--- a/tests/lib/Server/Output/ValueObjectVisitor/SectionListTest.php
+++ b/tests/lib/Server/Output/ValueObjectVisitor/SectionListTest.php
@@ -6,7 +6,7 @@
  */
 namespace Ibexa\Tests\Rest\Server\Output\ValueObjectVisitor;
 
-use Ibexa\Core\Repository\Values\Content;
+use Ibexa\Contracts\Core\Repository\Values\Content;
 use Ibexa\Rest\Server\Output\ValueObjectVisitor;
 use Ibexa\Rest\Server\Values\SectionList;
 use Ibexa\Tests\Rest\Output\ValueObjectVisitorBaseTest;

--- a/tests/lib/Server/Output/ValueObjectVisitor/SectionTest.php
+++ b/tests/lib/Server/Output/ValueObjectVisitor/SectionTest.php
@@ -6,7 +6,7 @@
  */
 namespace Ibexa\Tests\Rest\Server\Output\ValueObjectVisitor;
 
-use Ibexa\Core\Repository\Values\Content;
+use Ibexa\Contracts\Core\Repository\Values\Content;
 use Ibexa\Rest\Server\Output\ValueObjectVisitor;
 use Ibexa\Tests\Rest\Output\ValueObjectVisitorBaseTest;
 

--- a/tests/lib/Server/Output/ValueObjectVisitor/URLAliasListTest.php
+++ b/tests/lib/Server/Output/ValueObjectVisitor/URLAliasListTest.php
@@ -6,7 +6,7 @@
  */
 namespace Ibexa\Tests\Rest\Server\Output\ValueObjectVisitor;
 
-use Ibexa\Core\Repository\Values\Content;
+use Ibexa\Contracts\Core\Repository\Values\Content;
 use Ibexa\Rest\Server\Output\ValueObjectVisitor;
 use Ibexa\Rest\Server\Values\URLAliasList;
 use Ibexa\Tests\Rest\Output\ValueObjectVisitorBaseTest;

--- a/tests/lib/Server/Output/ValueObjectVisitor/URLAliasTest.php
+++ b/tests/lib/Server/Output/ValueObjectVisitor/URLAliasTest.php
@@ -6,7 +6,7 @@
  */
 namespace Ibexa\Tests\Rest\Server\Output\ValueObjectVisitor;
 
-use Ibexa\Core\Repository\Values\Content;
+use Ibexa\Contracts\Core\Repository\Values\Content;
 use Ibexa\Rest\Server\Output\ValueObjectVisitor;
 use Ibexa\Tests\Rest\Output\ValueObjectVisitorBaseTest;
 

--- a/tests/lib/Server/Output/ValueObjectVisitor/URLWildcardListTest.php
+++ b/tests/lib/Server/Output/ValueObjectVisitor/URLWildcardListTest.php
@@ -6,7 +6,7 @@
  */
 namespace Ibexa\Tests\Rest\Server\Output\ValueObjectVisitor;
 
-use Ibexa\Core\Repository\Values\Content;
+use Ibexa\Contracts\Core\Repository\Values\Content;
 use Ibexa\Rest\Server\Output\ValueObjectVisitor;
 use Ibexa\Rest\Server\Values\URLWildcardList;
 use Ibexa\Tests\Rest\Output\ValueObjectVisitorBaseTest;

--- a/tests/lib/Server/Output/ValueObjectVisitor/URLWildcardTest.php
+++ b/tests/lib/Server/Output/ValueObjectVisitor/URLWildcardTest.php
@@ -6,7 +6,7 @@
  */
 namespace Ibexa\Tests\Rest\Server\Output\ValueObjectVisitor;
 
-use Ibexa\Core\Repository\Values\Content;
+use Ibexa\Contracts\Core\Repository\Values\Content;
 use Ibexa\Rest\Server\Output\ValueObjectVisitor;
 use Ibexa\Tests\Rest\Output\ValueObjectVisitorBaseTest;
 


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [IBX-1334](https://jira.ez.no/browse/IBX-1334)
| **Type**| bug
| **Target version** | Ibexa 4.0
| **BC breaks**      | no
| **Doc needed**     | no

This PR fixes incorrect namespace import - `Ibexa\Contracts\Core\Repository\Values\Content;` instead of `Ibexa\Core\Repository\Values\Content`. It is used as `Content\*` in the code, so was not clearly visible, though tests failed.