### PR TITLE
IBX-1694: Rebranded dependency injection container service tags

### DIFF
--- a/src/bundle/DependencyInjection/Compiler/FieldTypeProcessorPass.php
+++ b/src/bundle/DependencyInjection/Compiler/FieldTypeProcessorPass.php
@@ -6,7 +6,6 @@
  */
 namespace Ibexa\Bundle\Rest\DependencyInjection\Compiler;
 
-use Ibexa\Core\Base\Container\Compiler\TaggedServiceIdsIterator\BackwardCompatibleIterator;
 use LogicException;
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
@@ -15,7 +14,6 @@ use Symfony\Component\DependencyInjection\Reference;
 class FieldTypeProcessorPass implements CompilerPassInterface
 {
     private const FIELD_TYPE_PROCESSOR_SERVICE_TAG = 'ibexa.rest.field_type.processor';
-    private const DEPRECATED_FIELD_TYPE_PROCESSOR_SERVICE_TAG = 'ezpublish_rest.field_type_processor';
 
     public function process(ContainerBuilder $container)
     {
@@ -25,21 +23,17 @@ class FieldTypeProcessorPass implements CompilerPassInterface
 
         $definition = $container->getDefinition('ezpublish_rest.field_type_processor_registry');
 
-        $iterator = new BackwardCompatibleIterator(
-            $container,
-            self::FIELD_TYPE_PROCESSOR_SERVICE_TAG,
-            self::DEPRECATED_FIELD_TYPE_PROCESSOR_SERVICE_TAG
+        $taggedServiceIds = $container->findTaggedServiceIds(
+            self::FIELD_TYPE_PROCESSOR_SERVICE_TAG
         );
-
-        foreach ($iterator as $serviceId => $attributes) {
+        foreach ($taggedServiceIds as $serviceId => $attributes) {
             foreach ($attributes as $attribute) {
                 if (!isset($attribute['alias'])) {
                     throw new LogicException(
                         sprintf(
-                            'Service "%s" tagged with "%s" or "%s" needs an "alias" attribute to identify the Field Type',
+                            'Service "%s" tagged with "%s" needs an "alias" attribute to identify the Field Type',
                             $serviceId,
-                            self::FIELD_TYPE_PROCESSOR_SERVICE_TAG,
-                            self::DEPRECATED_FIELD_TYPE_PROCESSOR_SERVICE_TAG
+                            self::FIELD_TYPE_PROCESSOR_SERVICE_TAG
                         )
                     );
                 }

--- a/src/bundle/DependencyInjection/Compiler/InputHandlerPass.php
+++ b/src/bundle/DependencyInjection/Compiler/InputHandlerPass.php
@@ -11,13 +11,15 @@ use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Reference;
 
 /**
- * Container processor for the ezpublish_rest.input.handler service tag.
+ * Container processor for the ibexa.rest.input.handler service tag.
  * Maps input formats (json, xml) to handlers.
  *
  * Tag attributes: format. Ex: json
  */
 class InputHandlerPass implements CompilerPassInterface
 {
+    public const INPUT_HANDLER_SERVICE_TAG = 'ibexa.rest.input.handler';
+
     public function process(ContainerBuilder $container)
     {
         if (!$container->hasDefinition('ezpublish_rest.input.dispatcher')) {
@@ -26,11 +28,16 @@ class InputHandlerPass implements CompilerPassInterface
 
         $definition = $container->getDefinition('ezpublish_rest.input.dispatcher');
 
-        // @todo rethink the relationships between registries. Rename if required.
-        foreach ($container->findTaggedServiceIds('ezpublish_rest.input.handler') as $id => $attributes) {
+        $taggedServiceIds = $container->findTaggedServiceIds(self::INPUT_HANDLER_SERVICE_TAG);
+        foreach ($taggedServiceIds as $id => $attributes) {
             foreach ($attributes as $attribute) {
                 if (!isset($attribute['format'])) {
-                    throw new \LogicException('The ezpublish_rest.input.handler service tag needs a "format" attribute to identify the input handler.');
+                    throw new \LogicException(
+                        sprintf(
+                            'The "%s" service tag needs a "format" attribute to identify the input handler.',
+                            self::INPUT_HANDLER_SERVICE_TAG
+                        )
+                    );
                 }
 
                 $definition->addMethodCall(

--- a/src/bundle/DependencyInjection/Compiler/InputParserPass.php
+++ b/src/bundle/DependencyInjection/Compiler/InputParserPass.php
@@ -11,13 +11,15 @@ use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Reference;
 
 /**
- * Container compiler processor for the ezpublish_rest.input.parser service tag.
+ * Container compiler processor for the ibexa.rest.input.parser service tag.
  * Maps input parsers to media types.
  *
  * Tag attributes: mediaType. Ex: application/vnd.ez.api.Content
  */
 class InputParserPass implements CompilerPassInterface
 {
+    public const INPUT_PARSER_SERVICE_TAG = 'ibexa.rest.input.parser';
+
     public function process(ContainerBuilder $container)
     {
         if (!$container->hasDefinition('ezpublish_rest.input.parsing_dispatcher')) {
@@ -26,10 +28,16 @@ class InputParserPass implements CompilerPassInterface
 
         $definition = $container->getDefinition('ezpublish_rest.input.parsing_dispatcher');
 
-        foreach ($container->findTaggedServiceIds('ezpublish_rest.input.parser') as $id => $attributes) {
+        $taggedServiceIds = $container->findTaggedServiceIds(self::INPUT_PARSER_SERVICE_TAG);
+        foreach ($taggedServiceIds as $id => $attributes) {
             foreach ($attributes as $attribute) {
                 if (!isset($attribute['mediaType'])) {
-                    throw new \LogicException('The ezpublish_rest.input.parser service tag needs a "mediaType" attribute to identify the input parser.');
+                    throw new \LogicException(
+                        sprintf(
+                            'The "%s" service tag needs a "mediaType" attribute to identify the input parser.',
+                            self::INPUT_PARSER_SERVICE_TAG
+                        )
+                    );
                 }
 
                 $definition->addMethodCall(

--- a/src/bundle/DependencyInjection/Compiler/OutputVisitorPass.php
+++ b/src/bundle/DependencyInjection/Compiler/OutputVisitorPass.php
@@ -12,7 +12,7 @@ use Symfony\Component\DependencyInjection\Exception\InvalidArgumentException;
 use Symfony\Component\DependencyInjection\Reference;
 
 /**
- * Compiler pass for the ezpublish_rest.output.visitor tag.
+ * Compiler pass for the ibexa.rest.output.visitor tag.
  *
  * Maps an output visitor (json, xml...) to an accept-header
  *
@@ -20,6 +20,8 @@ use Symfony\Component\DependencyInjection\Reference;
  */
 class OutputVisitorPass implements CompilerPassInterface
 {
+    public const OUTPUT_VISITOR_SERVICE_TAG = 'ibexa.rest.output.visitor';
+
     public function process(ContainerBuilder $container)
     {
         if (!$container->hasDefinition('ezpublish_rest.output.visitor.dispatcher')) {
@@ -30,12 +32,18 @@ class OutputVisitorPass implements CompilerPassInterface
 
         $visitors = [];
 
-        foreach ($container->findTaggedServiceIds('ezpublish_rest.output.visitor') as $id => $attributes) {
+        $taggedServiceIds = $container->findTaggedServiceIds(self::OUTPUT_VISITOR_SERVICE_TAG);
+        foreach ($taggedServiceIds as $id => $attributes) {
             foreach ($attributes as $attribute) {
-                $priority = isset($attribute['priority']) ? $attribute['priority'] : 0;
+                $priority = $attribute['priority'] ?? 0;
 
                 if (!isset($attribute['regexps'])) {
-                    throw new \LogicException('The ezpublish_rest.output.visitor service tag needs a "regexps" attribute to identify the Accept header.');
+                    throw new \LogicException(
+                        sprintf(
+                            'The "%s" service tag needs a "regexps" attribute to identify the Accept header.',
+                            self::OUTPUT_VISITOR_SERVICE_TAG
+                        )
+                    );
                 }
 
                 if (is_array($attribute['regexps'])) {

--- a/src/bundle/DependencyInjection/Compiler/ValueObjectVisitorPass.php
+++ b/src/bundle/DependencyInjection/Compiler/ValueObjectVisitorPass.php
@@ -11,11 +11,13 @@ use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Reference;
 
 /**
- * Compiler pass for the ezpublish_rest.output.value_object_visitor tag.
+ * Compiler pass for the ibexa.rest.output.value_object.visitor tag.
  * Maps an fully qualified class to a value object visitor.
  */
 class ValueObjectVisitorPass implements CompilerPassInterface
 {
+    public const OUTPUT_VALUE_OBJECT_VISITOR_SERVICE_TAG = 'ibexa.rest.output.value_object.visitor';
+
     public function process(ContainerBuilder $container)
     {
         if (!$container->hasDefinition('ezpublish_rest.output.value_object_visitor.dispatcher')) {
@@ -24,10 +26,18 @@ class ValueObjectVisitorPass implements CompilerPassInterface
 
         $definition = $container->getDefinition('ezpublish_rest.output.value_object_visitor.dispatcher');
 
-        foreach ($container->findTaggedServiceIds('ezpublish_rest.output.value_object_visitor') as $id => $attributes) {
+        $taggedServiceIds = $container->findTaggedServiceIds(
+            self::OUTPUT_VALUE_OBJECT_VISITOR_SERVICE_TAG
+        );
+        foreach ($taggedServiceIds as $id => $attributes) {
             foreach ($attributes as $attribute) {
                 if (!isset($attribute['type'])) {
-                    throw new \LogicException('The ezpublish_rest.output.value_object_visitor service tag needs a "type" attribute to identify the field type.');
+                    throw new \LogicException(
+                        sprintf(
+                            'The "%s" service tag needs a "type" attribute to identify the field type.',
+                            self::OUTPUT_VALUE_OBJECT_VISITOR_SERVICE_TAG
+                        )
+                    );
                 }
 
                 $definition->addMethodCall(

--- a/src/bundle/Resources/config/input_parsers.yml
+++ b/src/bundle/Resources/config/input_parsers.yml
@@ -89,7 +89,7 @@ services:
         parent: ezpublish_rest.input.parser
         class: "%ezpublish_rest.input.parser.ContentObjectStates.class%"
         tags:
-            - { name: ezpublish_rest.input.parser, mediaType: application/vnd.ez.api.ContentObjectStates }
+            - { name: ibexa.rest.input.parser, mediaType: application/vnd.ez.api.ContentObjectStates }
 
     # Rest server
 
@@ -103,13 +103,13 @@ services:
             - "@ezpublish_rest.input.parser.LocationCreate"
             - "@ezpublish_rest.parser_tools"
         tags:
-            - { name: ezpublish_rest.input.parser, mediaType: application/vnd.ez.api.ContentCreate }
+            - { name: ibexa.rest.input.parser, mediaType: application/vnd.ez.api.ContentCreate }
 
     ezpublish_rest.input.parser.ContentUpdate:
         parent: ezpublish_rest.input.parser
         class: "%ezpublish_rest.input.parser.ContentUpdate.class%"
         tags:
-            - { name: ezpublish_rest.input.parser, mediaType: application/vnd.ez.api.ContentUpdate }
+            - { name: ibexa.rest.input.parser, mediaType: application/vnd.ez.api.ContentUpdate }
 
     ezpublish_rest.input.parser.ContentTypeCreate:
         parent: ezpublish_rest.input.parser
@@ -119,7 +119,7 @@ services:
             - "@ezpublish_rest.input.parser.FieldDefinitionCreate"
             - "@ezpublish_rest.parser_tools"
         tags:
-            - { name: ezpublish_rest.input.parser, mediaType: application/vnd.ez.api.ContentTypeCreate }
+            - { name: ibexa.rest.input.parser, mediaType: application/vnd.ez.api.ContentTypeCreate }
 
     ezpublish_rest.input.parser.ContentTypeGroupInput:
         parent: ezpublish_rest.input.parser
@@ -128,7 +128,7 @@ services:
             - "@ezpublish.api.service.content_type"
             - "@ezpublish_rest.parser_tools"
         tags:
-            - { name: ezpublish_rest.input.parser, mediaType: application/vnd.ez.api.ContentTypeGroupInput }
+            - { name: ibexa.rest.input.parser, mediaType: application/vnd.ez.api.ContentTypeGroupInput }
 
     ezpublish_rest.input.parser.ContentTypeUpdate:
         parent: ezpublish_rest.input.parser
@@ -137,7 +137,7 @@ services:
             - "@ezpublish.api.service.content_type"
             - "@ezpublish_rest.parser_tools"
         tags:
-            - { name: ezpublish_rest.input.parser, mediaType: application/vnd.ez.api.ContentTypeUpdate }
+            - { name: ibexa.rest.input.parser, mediaType: application/vnd.ez.api.ContentTypeUpdate }
 
     ezpublish_rest.input.parser.FieldDefinitionCreate:
         parent: ezpublish_rest.input.parser
@@ -147,7 +147,7 @@ services:
             - "@ezpublish_rest.field_type_parser"
             - "@ezpublish_rest.parser_tools"
         tags:
-            - { name: ezpublish_rest.input.parser, mediaType: application/vnd.ez.api.FieldDefinitionCreate }
+            - { name: ibexa.rest.input.parser, mediaType: application/vnd.ez.api.FieldDefinitionCreate }
 
     ezpublish_rest.input.parser.FieldDefinitionUpdate:
         parent: ezpublish_rest.input.parser
@@ -157,12 +157,12 @@ services:
             - "@ezpublish_rest.field_type_parser"
             - "@ezpublish_rest.parser_tools"
         tags:
-            - { name: ezpublish_rest.input.parser, mediaType: application/vnd.ez.api.FieldDefinitionUpdate }
+            - { name: ibexa.rest.input.parser, mediaType: application/vnd.ez.api.FieldDefinitionUpdate }
 
     Ibexa\Rest\Server\Input\Parser\JWTInput:
         parent: ezpublish_rest.input.parser
         tags:
-            - { name: ezpublish_rest.input.parser, mediaType: application/vnd.ez.api.JWTInput }
+            - { name: ibexa.rest.input.parser, mediaType: application/vnd.ez.api.JWTInput }
 
     ezpublish_rest.input.parser.LocationCreate:
         parent: ezpublish_rest.input.parser
@@ -171,7 +171,7 @@ services:
             - "@ezpublish.api.service.location"
             - "@ezpublish_rest.parser_tools"
         tags:
-            - { name: ezpublish_rest.input.parser, mediaType: application/vnd.ez.api.LocationCreate }
+            - { name: ibexa.rest.input.parser, mediaType: application/vnd.ez.api.LocationCreate }
 
     ezpublish_rest.input.parser.LocationUpdate:
         parent: ezpublish_rest.input.parser
@@ -180,7 +180,7 @@ services:
             - "@ezpublish.api.service.location"
             - "@ezpublish_rest.parser_tools"
         tags:
-            - { name: ezpublish_rest.input.parser, mediaType: application/vnd.ez.api.LocationUpdate }
+            - { name: ibexa.rest.input.parser, mediaType: application/vnd.ez.api.LocationUpdate }
 
     ezpublish_rest.input.parser.ObjectStateGroupCreate:
         parent: ezpublish_rest.input.parser
@@ -189,7 +189,7 @@ services:
             - "@ezpublish.api.service.object_state"
             - "@ezpublish_rest.parser_tools"
         tags:
-            - { name: ezpublish_rest.input.parser, mediaType: application/vnd.ez.api.ObjectStateGroupCreate }
+            - { name: ibexa.rest.input.parser, mediaType: application/vnd.ez.api.ObjectStateGroupCreate }
 
     ezpublish_rest.input.parser.ObjectStateGroupUpdate:
         parent: ezpublish_rest.input.parser
@@ -198,7 +198,7 @@ services:
             - "@ezpublish.api.service.object_state"
             - "@ezpublish_rest.parser_tools"
         tags:
-            - { name: ezpublish_rest.input.parser, mediaType: application/vnd.ez.api.ObjectStateGroupUpdate }
+            - { name: ibexa.rest.input.parser, mediaType: application/vnd.ez.api.ObjectStateGroupUpdate }
 
     ezpublish_rest.input.parser.ObjectStateCreate:
         parent: ezpublish_rest.input.parser
@@ -207,7 +207,7 @@ services:
             - "@ezpublish.api.service.object_state"
             - "@ezpublish_rest.parser_tools"
         tags:
-            - { name: ezpublish_rest.input.parser, mediaType: application/vnd.ez.api.ObjectStateCreate }
+            - { name: ibexa.rest.input.parser, mediaType: application/vnd.ez.api.ObjectStateCreate }
 
     ezpublish_rest.input.parser.ObjectStateUpdate:
         parent: ezpublish_rest.input.parser
@@ -216,7 +216,7 @@ services:
             - "@ezpublish.api.service.object_state"
             - "@ezpublish_rest.parser_tools"
         tags:
-            - { name: ezpublish_rest.input.parser, mediaType: application/vnd.ez.api.ObjectStateUpdate }
+            - { name: ibexa.rest.input.parser, mediaType: application/vnd.ez.api.ObjectStateUpdate }
 
     ezpublish_rest.input.parser.PolicyCreate:
         parent: ezpublish_rest.input.parser
@@ -225,7 +225,7 @@ services:
             - "@ezpublish.api.service.role"
             - "@ezpublish_rest.parser_tools"
         tags:
-            - { name: ezpublish_rest.input.parser, mediaType: application/vnd.ez.api.PolicyCreate }
+            - { name: ibexa.rest.input.parser, mediaType: application/vnd.ez.api.PolicyCreate }
 
     ezpublish_rest.input.parser.PolicyUpdate:
         parent: ezpublish_rest.input.parser
@@ -234,13 +234,13 @@ services:
             - "@ezpublish.api.service.role"
             - "@ezpublish_rest.parser_tools"
         tags:
-            - { name: ezpublish_rest.input.parser, mediaType: application/vnd.ez.api.PolicyUpdate }
+            - { name: ibexa.rest.input.parser, mediaType: application/vnd.ez.api.PolicyUpdate }
 
     ezpublish_rest.input.parser.RelationCreate:
         parent: ezpublish_rest.input.parser
         class: "%ezpublish_rest.input.parser.RelationCreate.class%"
         tags:
-            - { name: ezpublish_rest.input.parser, mediaType: application/vnd.ez.api.RelationCreate }
+            - { name: ibexa.rest.input.parser, mediaType: application/vnd.ez.api.RelationCreate }
 
     ezpublish_rest.input.parser.RoleAssignInput:
         parent: ezpublish_rest.input.parser
@@ -248,7 +248,7 @@ services:
         arguments:
             - "@ezpublish_rest.parser_tools"
         tags:
-            - { name: ezpublish_rest.input.parser, mediaType: application/vnd.ez.api.RoleAssignInput }
+            - { name: ibexa.rest.input.parser, mediaType: application/vnd.ez.api.RoleAssignInput }
 
     ezpublish_rest.input.parser.RoleInput:
         parent: ezpublish_rest.input.parser
@@ -257,7 +257,7 @@ services:
             - "@ezpublish.api.service.role"
             - "@ezpublish_rest.parser_tools"
         tags:
-            - { name: ezpublish_rest.input.parser, mediaType: application/vnd.ez.api.RoleInput }
+            - { name: ibexa.rest.input.parser, mediaType: application/vnd.ez.api.RoleInput }
 
     ezpublish_rest.input.parser.SectionInput:
         parent: ezpublish_rest.input.parser
@@ -265,7 +265,7 @@ services:
         arguments:
             - "@ezpublish.api.service.section"
         tags:
-            - { name: ezpublish_rest.input.parser, mediaType: application/vnd.ez.api.SectionInput }
+            - { name: ibexa.rest.input.parser, mediaType: application/vnd.ez.api.SectionInput }
 
     ezpublish_rest.input.parser.SessionInput:
         parent: ezpublish_rest.input.parser
@@ -273,7 +273,7 @@ services:
         arguments:
             - "@ezpublish_rest.parser_tools"
         tags:
-            - { name: ezpublish_rest.input.parser, mediaType: application/vnd.ez.api.SessionInput }
+            - { name: ibexa.rest.input.parser, mediaType: application/vnd.ez.api.SessionInput }
 
     ezpublish_rest.input.parser.UserGroupUpdate:
         parent: ezpublish_rest.input.parser
@@ -284,7 +284,7 @@ services:
             - "@ezpublish.api.service.location"
             - "@ezpublish_rest.field_type_parser"
         tags:
-            - { name: ezpublish_rest.input.parser, mediaType: application/vnd.ez.api.UserGroupUpdate }
+            - { name: ibexa.rest.input.parser, mediaType: application/vnd.ez.api.UserGroupUpdate }
 
     ezpublish_rest.input.parser.URLAliasCreate:
         parent: ezpublish_rest.input.parser
@@ -292,7 +292,7 @@ services:
         arguments:
             - "@ezpublish_rest.parser_tools"
         tags:
-            - { name: ezpublish_rest.input.parser, mediaType: application/vnd.ez.api.UrlAliasCreate }
+            - { name: ibexa.rest.input.parser, mediaType: application/vnd.ez.api.UrlAliasCreate }
 
     ezpublish_rest.input.parser.URLWildcardCreate:
         parent: ezpublish_rest.input.parser
@@ -300,7 +300,7 @@ services:
         arguments:
             - "@ezpublish_rest.parser_tools"
         tags:
-            - { name: ezpublish_rest.input.parser, mediaType: application/vnd.ez.api.UrlWildcardCreate }
+            - { name: ibexa.rest.input.parser, mediaType: application/vnd.ez.api.UrlWildcardCreate }
 
     ezpublish_rest.input.parser.UserCreate:
         parent: ezpublish_rest.input.parser
@@ -311,7 +311,7 @@ services:
             - "@ezpublish_rest.field_type_parser"
             - "@ezpublish_rest.parser_tools"
         tags:
-            - { name: ezpublish_rest.input.parser, mediaType: application/vnd.ez.api.UserCreate }
+            - { name: ibexa.rest.input.parser, mediaType: application/vnd.ez.api.UserCreate }
 
     ezpublish_rest.input.parser.UserGroupCreate:
         parent: ezpublish_rest.input.parser
@@ -321,7 +321,7 @@ services:
             - "@ezpublish.api.service.content_type"
             - "@ezpublish_rest.field_type_parser"
         tags:
-            - { name: ezpublish_rest.input.parser, mediaType: application/vnd.ez.api.UserGroupCreate }
+            - { name: ibexa.rest.input.parser, mediaType: application/vnd.ez.api.UserGroupCreate }
 
     ezpublish_rest.input.parser.UserUpdate:
         parent: ezpublish_rest.input.parser
@@ -332,19 +332,19 @@ services:
             - "@ezpublish_rest.field_type_parser"
             - "@ezpublish_rest.parser_tools"
         tags:
-            - { name: ezpublish_rest.input.parser, mediaType: application/vnd.ez.api.UserUpdate }
+            - { name: ibexa.rest.input.parser, mediaType: application/vnd.ez.api.UserUpdate }
 
     ezpublish_rest.input.parser.ViewInput:
         parent: ezpublish_rest.input.parser
         class: "%ezpublish_rest.input.parser.ViewInput.class%"
         tags:
-            - { name: ezpublish_rest.input.parser, mediaType: application/vnd.ez.api.ViewInput }
+            - { name: ibexa.rest.input.parser, mediaType: application/vnd.ez.api.ViewInput }
 
     ezpublish_rest.input.parser.ViewInputOnedotOne:
         parent: ezpublish_rest.input.parser
         class: "%ezpublish_rest.input.parser.ViewInputOneDotOne.class%"
         tags:
-            - { name: ezpublish_rest.input.parser, mediaType: "application/vnd.ez.api.ViewInput; version=1.1" }
+            - { name: ibexa.rest.input.parser, mediaType: "application/vnd.ez.api.ViewInput; version=1.1" }
 
     ezpublish_rest.input.parser.VersionUpdate:
         parent: ezpublish_rest.input.parser
@@ -353,50 +353,50 @@ services:
             - "@ezpublish.api.service.content"
             - "@ezpublish_rest.field_type_parser"
         tags:
-            - { name: ezpublish_rest.input.parser, mediaType: application/vnd.ez.api.VersionUpdate }
+            - { name: ibexa.rest.input.parser, mediaType: application/vnd.ez.api.VersionUpdate }
 
     # internal Media-Types
     ezpublish_rest.input.parser.internal.criterion.ContentQuery:
         parent: ezpublish_rest.input.parser
         class: "%ezpublish_rest.input.parser.internal.ContentQuery.class%"
         tags:
-            - { name: ezpublish_rest.input.parser, mediaType: application/vnd.ez.api.internal.ContentQuery }
+            - { name: ibexa.rest.input.parser, mediaType: application/vnd.ez.api.internal.ContentQuery }
 
     ezpublish_rest.input.parser.internal.criterion.LocationQuery:
         parent: ezpublish_rest.input.parser
         class: "%ezpublish_rest.input.parser.internal.LocationQuery.class%"
         tags:
-            - { name: ezpublish_rest.input.parser, mediaType: application/vnd.ez.api.internal.LocationQuery }
+            - { name: ibexa.rest.input.parser, mediaType: application/vnd.ez.api.internal.LocationQuery }
 
     ezpublish_rest.input.parser.internal.criterion.Ancestor:
         parent: ezpublish_rest.input.parser
         class: "%ezpublish_rest.input.parser.internal.criterion.Ancestor.class%"
         tags:
-            - { name: ezpublish_rest.input.parser, mediaType: application/vnd.ez.api.internal.criterion.Ancestor }
+            - { name: ibexa.rest.input.parser, mediaType: application/vnd.ez.api.internal.criterion.Ancestor }
 
     ezpublish_rest.input.parser.internal.criterion.ContentId:
         parent: ezpublish_rest.input.parser
         class: "%ezpublish_rest.input.parser.internal.criterion.ContentId.class%"
         tags:
-            - { name: ezpublish_rest.input.parser, mediaType: application/vnd.ez.api.internal.criterion.ContentId }
+            - { name: ibexa.rest.input.parser, mediaType: application/vnd.ez.api.internal.criterion.ContentId }
 
     ezpublish_rest.input.parser.internal.criterion.ContentRemoteId:
         parent: ezpublish_rest.input.parser
         class: "%ezpublish_rest.input.parser.internal.criterion.ContentRemoteId.class%"
         tags:
-            - { name: ezpublish_rest.input.parser, mediaType: application/vnd.ez.api.internal.criterion.ContentRemoteId }
+            - { name: ibexa.rest.input.parser, mediaType: application/vnd.ez.api.internal.criterion.ContentRemoteId }
 
     ezpublish_rest.input.parser.internal.criterion.ContentTypeGroupId:
         parent: ezpublish_rest.input.parser
         class: "%ezpublish_rest.input.parser.internal.criterion.ContentTypeGroupId.class%"
         tags:
-            - { name: ezpublish_rest.input.parser, mediaType: application/vnd.ez.api.internal.criterion.ContentTypeGroupId }
+            - { name: ibexa.rest.input.parser, mediaType: application/vnd.ez.api.internal.criterion.ContentTypeGroupId }
 
     ezpublish_rest.input.parser.internal.criterion.ContentTypeId:
         parent: ezpublish_rest.input.parser
         class: "%ezpublish_rest.input.parser.internal.criterion.ContentTypeId.class%"
         tags:
-            - { name: ezpublish_rest.input.parser, mediaType: application/vnd.ez.api.internal.criterion.ContentTypeId }
+            - { name: ibexa.rest.input.parser, mediaType: application/vnd.ez.api.internal.criterion.ContentTypeId }
 
     ezpublish_rest.input.parser.internal.criterion.ContentTypeIdentifier:
         parent: ezpublish_rest.input.parser
@@ -404,84 +404,84 @@ services:
         arguments:
             - "@ezpublish.api.service.content_type"
         tags:
-            - { name: ezpublish_rest.input.parser, mediaType: application/vnd.ez.api.internal.criterion.ContentTypeIdentifier }
+            - { name: ibexa.rest.input.parser, mediaType: application/vnd.ez.api.internal.criterion.ContentTypeIdentifier }
 
     ezpublish_rest.input.parser.internal.criterion.DateMetadata:
         parent: ezpublish_rest.input.parser
         class: "%ezpublish_rest.input.parser.internal.criterion.DateMetadata.class%"
         tags:
-            - { name: ezpublish_rest.input.parser, mediaType: application/vnd.ez.api.internal.criterion.DateMetadata }
+            - { name: ibexa.rest.input.parser, mediaType: application/vnd.ez.api.internal.criterion.DateMetadata }
 
     ezpublish_rest.input.parser.internal.criterion.Field:
         parent: ezpublish_rest.input.parser
         class: "%ezpublish_rest.input.parser.internal.criterion.Field.class%"
         tags:
-            - { name: ezpublish_rest.input.parser, mediaType: application/vnd.ez.api.internal.criterion.Field }
+            - { name: ibexa.rest.input.parser, mediaType: application/vnd.ez.api.internal.criterion.Field }
 
     ezpublish_rest.input.parser.internal.criterion.FullText:
         parent: ezpublish_rest.input.parser
         class: "%ezpublish_rest.input.parser.internal.criterion.FullText.class%"
         tags:
-            - { name: ezpublish_rest.input.parser, mediaType: application/vnd.ez.api.internal.criterion.FullText }
+            - { name: ibexa.rest.input.parser, mediaType: application/vnd.ez.api.internal.criterion.FullText }
 
     ezpublish_rest.input.parser.internal.criterion.LanguageCode:
         parent: ezpublish_rest.input.parser
         class: "%ezpublish_rest.input.parser.internal.criterion.LanguageCode.class%"
         tags:
-            - { name: ezpublish_rest.input.parser, mediaType: application/vnd.ez.api.internal.criterion.LanguageCode }
+            - { name: ibexa.rest.input.parser, mediaType: application/vnd.ez.api.internal.criterion.LanguageCode }
     ezpublish_rest.input.parser.internal.criterion.LocationId:
         parent: ezpublish_rest.input.parser
         class: "%ezpublish_rest.input.parser.internal.criterion.LocationId.class%"
         tags:
-            - { name: ezpublish_rest.input.parser, mediaType: application/vnd.ez.api.internal.criterion.LocationId }
+            - { name: ibexa.rest.input.parser, mediaType: application/vnd.ez.api.internal.criterion.LocationId }
 
     ezpublish_rest.input.parser.internal.criterion.LocationRemoteId:
         parent: ezpublish_rest.input.parser
         class: "%ezpublish_rest.input.parser.internal.criterion.LocationRemoteId.class%"
         tags:
-            - { name: ezpublish_rest.input.parser, mediaType: application/vnd.ez.api.internal.criterion.LocationRemoteId }
+            - { name: ibexa.rest.input.parser, mediaType: application/vnd.ez.api.internal.criterion.LocationRemoteId }
 
     ezpublish_rest.input.parser.internal.criterion.LogicalAnd:
         parent: ezpublish_rest.input.parser
         class: "%ezpublish_rest.input.parser.internal.criterion.LogicalAnd.class%"
         tags:
-            - { name: ezpublish_rest.input.parser, mediaType: application/vnd.ez.api.internal.criterion.LogicalAnd }
+            - { name: ibexa.rest.input.parser, mediaType: application/vnd.ez.api.internal.criterion.LogicalAnd }
 
     ezpublish_rest.input.parser.internal.criterion.LogicalNot:
         parent: ezpublish_rest.input.parser
         class: "%ezpublish_rest.input.parser.internal.criterion.LogicalNot.class%"
         tags:
-            - { name: ezpublish_rest.input.parser, mediaType: application/vnd.ez.api.internal.criterion.LogicalNot }
+            - { name: ibexa.rest.input.parser, mediaType: application/vnd.ez.api.internal.criterion.LogicalNot }
 
     ezpublish_rest.input.parser.internal.criterion.LogicalOperator:
         parent: ezpublish_rest.input.parser
         class: "%ezpublish_rest.input.parser.internal.criterion.LogicalOperator.class%"
         tags:
-            - { name: ezpublish_rest.input.parser, mediaType: application/vnd.ez.api.internal.criterion.LogicalOperator }
+            - { name: ibexa.rest.input.parser, mediaType: application/vnd.ez.api.internal.criterion.LogicalOperator }
 
     ezpublish_rest.input.parser.internal.criterion.LogicalOr:
         parent: ezpublish_rest.input.parser
         class: "%ezpublish_rest.input.parser.internal.criterion.LogicalOr.class%"
         tags:
-            - { name: ezpublish_rest.input.parser, mediaType: application/vnd.ez.api.internal.criterion.LogicalOr }
+            - { name: ibexa.rest.input.parser, mediaType: application/vnd.ez.api.internal.criterion.LogicalOr }
 
     ezpublish_rest.input.parser.internal.criterion.MoreLikeThis:
         parent: ezpublish_rest.input.parser
         class: "%ezpublish_rest.input.parser.internal.criterion.MoreLikeThis.class%"
         tags:
-            - { name: ezpublish_rest.input.parser, mediaType: application/vnd.ez.api.internal.criterion.MoreLikeThis }
+            - { name: ibexa.rest.input.parser, mediaType: application/vnd.ez.api.internal.criterion.MoreLikeThis }
 
     ezpublish_rest.input.parser.internal.criterion.Operator:
         parent: ezpublish_rest.input.parser
         class: "%ezpublish_rest.input.parser.internal.criterion.Operator.class%"
         tags:
-            - { name: ezpublish_rest.input.parser, mediaType: application/vnd.ez.api.internal.criterion.Operator }
+            - { name: ibexa.rest.input.parser, mediaType: application/vnd.ez.api.internal.criterion.Operator }
 
     ezpublish_rest.input.parser.internal.criterion.ParentLocationId:
         parent: ezpublish_rest.input.parser
         class: "%ezpublish_rest.input.parser.internal.criterion.ParentLocationId.class%"
         tags:
-            - { name: ezpublish_rest.input.parser, mediaType: application/vnd.ez.api.internal.criterion.ParentLocationId }
+            - { name: ibexa.rest.input.parser, mediaType: application/vnd.ez.api.internal.criterion.ParentLocationId }
 
     ezpublish_rest.input.parser.internal.criterion.ParentLocationRemoteId:
         parent: ezpublish_rest.input.parser
@@ -489,7 +489,7 @@ services:
         arguments:
             - "@ezpublish.api.service.location"
         tags:
-            - { name: ezpublish_rest.input.parser, mediaType: application/vnd.ez.api.internal.criterion.ParentLocationRemoteId }
+            - { name: ibexa.rest.input.parser, mediaType: application/vnd.ez.api.internal.criterion.ParentLocationRemoteId }
 
     ezpublish_rest.input.parser.internal.criterion.SectionIdentifier:
         parent: ezpublish_rest.input.parser
@@ -497,78 +497,78 @@ services:
         arguments:
             - "@ezpublish.api.service.section"
         tags:
-            - { name: ezpublish_rest.input.parser, mediaType: application/vnd.ez.api.internal.criterion.SectionIdentifier }
+            - { name: ibexa.rest.input.parser, mediaType: application/vnd.ez.api.internal.criterion.SectionIdentifier }
 
     ezpublish_rest.input.parser.internal.criterion.SectionId:
         parent: ezpublish_rest.input.parser
         class: "%ezpublish_rest.input.parser.internal.criterion.SectionId.class%"
         tags:
-            - { name: ezpublish_rest.input.parser, mediaType: application/vnd.ez.api.internal.criterion.SectionId }
+            - { name: ibexa.rest.input.parser, mediaType: application/vnd.ez.api.internal.criterion.SectionId }
 
     ezpublish_rest.input.parser.internal.criterion.Subtree:
         parent: ezpublish_rest.input.parser
         class: "%ezpublish_rest.input.parser.internal.criterion.Subtree.class%"
         tags:
-            - { name: ezpublish_rest.input.parser, mediaType: application/vnd.ez.api.internal.criterion.Subtree }
+            - { name: ibexa.rest.input.parser, mediaType: application/vnd.ez.api.internal.criterion.Subtree }
 
     ezpublish_rest.input.parser.internal.criterion.UserMetadata:
         parent: ezpublish_rest.input.parser
         class: "%ezpublish_rest.input.parser.internal.criterion.UserMetadata.class%"
         tags:
-            - { name: ezpublish_rest.input.parser, mediaType: application/vnd.ez.api.internal.criterion.UserMetadata }
+            - { name: ibexa.rest.input.parser, mediaType: application/vnd.ez.api.internal.criterion.UserMetadata }
 
     Ibexa\Rest\Server\Input\Parser\Criterion\IsUserBased:
         parent: ezpublish_rest.input.parser
         arguments:
             $parserTools: '@ezpublish_rest.parser_tools'
         tags:
-            - { name: ezpublish_rest.input.parser, mediaType: application/vnd.ez.api.internal.criterion.IsUserBased }
+            - { name: ibexa.rest.input.parser, mediaType: application/vnd.ez.api.internal.criterion.IsUserBased }
 
     Ibexa\Rest\Server\Input\Parser\Criterion\IsUserEnabled:
         parent: ezpublish_rest.input.parser
         arguments:
             $parserTools: '@ezpublish_rest.parser_tools'
         tags:
-            - { name: ezpublish_rest.input.parser, mediaType: application/vnd.ez.api.internal.criterion.IsUserEnabled }
+            - { name: ibexa.rest.input.parser, mediaType: application/vnd.ez.api.internal.criterion.IsUserEnabled }
 
     Ibexa\Rest\Server\Input\Parser\Criterion\UserId:
         parent: ezpublish_rest.input.parser
         tags:
-            - { name: ezpublish_rest.input.parser, mediaType: application/vnd.ez.api.internal.criterion.UserId }
+            - { name: ibexa.rest.input.parser, mediaType: application/vnd.ez.api.internal.criterion.UserId }
 
     Ibexa\Rest\Server\Input\Parser\Criterion\UserLogin:
         parent: ezpublish_rest.input.parser
         tags:
-            - { name: ezpublish_rest.input.parser, mediaType: application/vnd.ez.api.internal.criterion.UserLogin }
+            - { name: ibexa.rest.input.parser, mediaType: application/vnd.ez.api.internal.criterion.UserLogin }
 
     Ibexa\Rest\Server\Input\Parser\Criterion\UserEmail:
         parent: ezpublish_rest.input.parser
         tags:
-            - { name: ezpublish_rest.input.parser, mediaType: application/vnd.ez.api.internal.criterion.UserEmail }
+            - { name: ibexa.rest.input.parser, mediaType: application/vnd.ez.api.internal.criterion.UserEmail }
 
     ezpublish_rest.input.parser.internal.criterion.ObjectStateId:
         parent: ezpublish_rest.input.parser
         class: "%ezpublish_rest.input.parser.internal.criterion.ObjectStateId.class%"
         tags:
-            - { name: ezpublish_rest.input.parser, mediaType: application/vnd.ez.api.internal.criterion.ObjectStateId }
+            - { name: ibexa.rest.input.parser, mediaType: application/vnd.ez.api.internal.criterion.ObjectStateId }
 
     Ibexa\Rest\Server\Input\Parser\Criterion\ObjectStateIdentifier:
         parent: ezpublish_rest.input.parser
         tags:
-            - { name: ezpublish_rest.input.parser, mediaType: application/vnd.ez.api.internal.criterion.ObjectStateIdentifier }
+            - { name: ibexa.rest.input.parser, mediaType: application/vnd.ez.api.internal.criterion.ObjectStateIdentifier }
 
     ezpublish_rest.input.parser.internal.criterion.Visibility:
         parent: ezpublish_rest.input.parser
         class: "%ezpublish_rest.input.parser.internal.criterion.Visibility.class%"
         tags:
-            - { name: ezpublish_rest.input.parser, mediaType: application/vnd.ez.api.internal.criterion.Visibility }
+            - { name: ibexa.rest.input.parser, mediaType: application/vnd.ez.api.internal.criterion.Visibility }
 
     Ibexa\Rest\Server\Input\Parser\Criterion\Sibling:
         parent: ezpublish_rest.input.parser
         arguments:
             $locationService: "@ezpublish.api.service.location"
         tags:
-            - { name: ezpublish_rest.input.parser, mediaType: application/vnd.ez.api.internal.criterion.Sibling }
+            - { name: ibexa.rest.input.parser, mediaType: application/vnd.ez.api.internal.criterion.Sibling }
 
     ezpublish_rest.input.parser.internal.sortclause.content_id:
         parent: ezpublish_rest.input.parser
@@ -577,7 +577,7 @@ services:
             - 'ContentId'
             - 'Ibexa\Contracts\Core\Repository\Values\Content\Query\SortClause\ContentId'
         tags:
-            - { name: ezpublish_rest.input.parser, mediaType: application/vnd.ez.api.internal.sortclause.ContentId }
+            - { name: ibexa.rest.input.parser, mediaType: application/vnd.ez.api.internal.sortclause.ContentId }
 
     ezpublish_rest.input.parser.internal.sortclause.content_name:
         parent: ezpublish_rest.input.parser
@@ -586,7 +586,7 @@ services:
             - 'ContentName'
             - 'Ibexa\Contracts\Core\Repository\Values\Content\Query\SortClause\ContentName'
         tags:
-            - { name: ezpublish_rest.input.parser, mediaType: application/vnd.ez.api.internal.sortclause.ContentName }
+            - { name: ibexa.rest.input.parser, mediaType: application/vnd.ez.api.internal.sortclause.ContentName }
 
     ezpublish_rest.input.parser.internal.sortclause.date_modified:
         parent: ezpublish_rest.input.parser
@@ -595,7 +595,7 @@ services:
             - 'DateModified'
             - 'Ibexa\Contracts\Core\Repository\Values\Content\Query\SortClause\DateModified'
         tags:
-            - { name: ezpublish_rest.input.parser, mediaType: application/vnd.ez.api.internal.sortclause.DateModified }
+            - { name: ibexa.rest.input.parser, mediaType: application/vnd.ez.api.internal.sortclause.DateModified }
 
     ezpublish_rest.input.parser.internal.sortclause.date_published:
         parent: ezpublish_rest.input.parser
@@ -604,7 +604,7 @@ services:
             - 'DatePublished'
             - 'Ibexa\Contracts\Core\Repository\Values\Content\Query\SortClause\DatePublished'
         tags:
-            - { name: ezpublish_rest.input.parser, mediaType: application/vnd.ez.api.internal.sortclause.DatePublished }
+            - { name: ibexa.rest.input.parser, mediaType: application/vnd.ez.api.internal.sortclause.DatePublished }
 
     ezpublish_rest.input.parser.internal.sortclause.location_depth:
         parent: ezpublish_rest.input.parser
@@ -613,7 +613,7 @@ services:
             - 'LocationDepth'
             - 'Ibexa\Contracts\Core\Repository\Values\Content\Query\SortClause\Location\Depth'
         tags:
-            - { name: ezpublish_rest.input.parser, mediaType: application/vnd.ez.api.internal.sortclause.LocationDepth }
+            - { name: ibexa.rest.input.parser, mediaType: application/vnd.ez.api.internal.sortclause.LocationDepth }
 
     ezpublish_rest.input.parser.internal.sortclause.location_path:
         parent: ezpublish_rest.input.parser
@@ -622,7 +622,7 @@ services:
             - 'LocationPath'
             - 'Ibexa\Contracts\Core\Repository\Values\Content\Query\SortClause\Location\Path'
         tags:
-            - { name: ezpublish_rest.input.parser, mediaType: application/vnd.ez.api.internal.sortclause.LocationPath }
+            - { name: ibexa.rest.input.parser, mediaType: application/vnd.ez.api.internal.sortclause.LocationPath }
 
     ezpublish_rest.input.parser.internal.sortclause.location_priority:
         parent: ezpublish_rest.input.parser
@@ -631,7 +631,7 @@ services:
             - 'LocationPriority'
             - 'Ibexa\Contracts\Core\Repository\Values\Content\Query\SortClause\Location\Priority'
         tags:
-            - { name: ezpublish_rest.input.parser, mediaType: application/vnd.ez.api.internal.sortclause.LocationPriority }
+            - { name: ibexa.rest.input.parser, mediaType: application/vnd.ez.api.internal.sortclause.LocationPriority }
 
     ezpublish_rest.input.parser.internal.sortclause.location_id:
         parent: ezpublish_rest.input.parser
@@ -640,7 +640,7 @@ services:
             - 'LocationId'
             - 'Ibexa\Contracts\Core\Repository\Values\Content\Query\SortClause\Location\Id'
         tags:
-            - { name: ezpublish_rest.input.parser, mediaType: application/vnd.ez.api.internal.sortclause.LocationId }
+            - { name: ibexa.rest.input.parser, mediaType: application/vnd.ez.api.internal.sortclause.LocationId }
 
     ezpublish_rest.input.parser.internal.sortclause.section_identifier:
         parent: ezpublish_rest.input.parser
@@ -649,7 +649,7 @@ services:
             - 'SectionIdentifier'
             - 'Ibexa\Contracts\Core\Repository\Values\Content\Query\SortClause\SectionIdentifier'
         tags:
-            - { name: ezpublish_rest.input.parser, mediaType: application/vnd.ez.api.internal.sortclause.SectionIdentifier }
+            - { name: ibexa.rest.input.parser, mediaType: application/vnd.ez.api.internal.sortclause.SectionIdentifier }
 
     ezpublish_rest.input.parser.internal.sortclause.SectionName:
         parent: ezpublish_rest.input.parser
@@ -658,7 +658,7 @@ services:
             - 'SectionName'
             - 'Ibexa\Contracts\Core\Repository\Values\Content\Query\SortClause\SectionName'
         tags:
-            - { name: ezpublish_rest.input.parser, mediaType: application/vnd.ez.api.internal.sortclause.SectionName }
+            - { name: ibexa.rest.input.parser, mediaType: application/vnd.ez.api.internal.sortclause.SectionName }
 
     ezpublish_rest.input.parser.internal.sortclause.score:
         parent: ezpublish_rest.input.parser
@@ -667,209 +667,209 @@ services:
             - 'Score'
             - 'Ibexa\Contracts\Core\Repository\Values\Content\Query\SortClause\Score'
         tags:
-            - { name: ezpublish_rest.input.parser, mediaType: application/vnd.ez.api.internal.sortclause.Score }
+            - { name: ibexa.rest.input.parser, mediaType: application/vnd.ez.api.internal.sortclause.Score }
 
     ezpublish_rest.input.parser.internal.sortclause.Field:
         parent: ezpublish_rest.input.parser
         class: '%ezpublish_rest.input.parser.internal.sortclause.field.class%'
         tags:
-            - { name: ezpublish_rest.input.parser, mediaType: application/vnd.ez.api.internal.sortclause.Field }
+            - { name: ibexa.rest.input.parser, mediaType: application/vnd.ez.api.internal.sortclause.Field }
 
     ezpublish_rest.input.parser.internal.facetbuilder.content_type:
         parent: ezpublish_rest.input.parser
         class: '%ezpublish_rest.input.parser.internal.facetbuilder.content_type.class%'
         tags:
-            - { name: ezpublish_rest.input.parser, mediaType: application/vnd.ez.api.internal.facetbuilder.ContentType }
+            - { name: ibexa.rest.input.parser, mediaType: application/vnd.ez.api.internal.facetbuilder.ContentType }
 
     ezpublish_rest.input.parser.internal.facetbuilder.criterion:
         parent: ezpublish_rest.input.parser
         class: '%ezpublish_rest.input.parser.internal.facetbuilder.criterion.class%'
         tags:
-            - { name: ezpublish_rest.input.parser, mediaType: application/vnd.ez.api.internal.facetbuilder.Criterion }
+            - { name: ibexa.rest.input.parser, mediaType: application/vnd.ez.api.internal.facetbuilder.Criterion }
 
     ezpublish_rest.input.parser.internal.facetbuilder.date_range:
         parent: ezpublish_rest.input.parser
         class: '%ezpublish_rest.input.parser.internal.facetbuilder.date_range.class%'
         tags:
-            - { name: ezpublish_rest.input.parser, mediaType: application/vnd.ez.api.internal.facetbuilder.DateRange }
+            - { name: ibexa.rest.input.parser, mediaType: application/vnd.ez.api.internal.facetbuilder.DateRange }
 
     ezpublish_rest.input.parser.internal.facetbuilder.field:
         parent: ezpublish_rest.input.parser
         class: '%ezpublish_rest.input.parser.internal.facetbuilder.field.class%'
         tags:
-            - { name: ezpublish_rest.input.parser, mediaType: application/vnd.ez.api.internal.facetbuilder.Field }
+            - { name: ibexa.rest.input.parser, mediaType: application/vnd.ez.api.internal.facetbuilder.Field }
 
     ezpublish_rest.input.parser.internal.facetbuilder.field_range:
         parent: ezpublish_rest.input.parser
         class: '%ezpublish_rest.input.parser.internal.facetbuilder.field_range.class%'
         tags:
-            - { name: ezpublish_rest.input.parser, mediaType: application/vnd.ez.api.internal.facetbuilder.FieldRange }
+            - { name: ibexa.rest.input.parser, mediaType: application/vnd.ez.api.internal.facetbuilder.FieldRange }
 
     ezpublish_rest.input.parser.internal.facetbuilder.location:
         parent: ezpublish_rest.input.parser
         class: '%ezpublish_rest.input.parser.internal.facetbuilder.location.class%'
         tags:
-            - { name: ezpublish_rest.input.parser, mediaType: application/vnd.ez.api.internal.facetbuilder.Location }
+            - { name: ibexa.rest.input.parser, mediaType: application/vnd.ez.api.internal.facetbuilder.Location }
 
     ezpublish_rest.input.parser.internal.facetbuilder.section:
         parent: ezpublish_rest.input.parser
         class: '%ezpublish_rest.input.parser.internal.facetbuilder.section.class%'
         tags:
-            - { name: ezpublish_rest.input.parser, mediaType: application/vnd.ez.api.internal.facetbuilder.Section }
+            - { name: ibexa.rest.input.parser, mediaType: application/vnd.ez.api.internal.facetbuilder.Section }
 
     ezpublish_rest.input.parser.internal.facetbuilder.term:
         parent: ezpublish_rest.input.parser
         class: '%ezpublish_rest.input.parser.internal.facetbuilder.term.class%'
         tags:
-            - { name: ezpublish_rest.input.parser, mediaType: application/vnd.ez.api.internal.facetbuilder.Term }
+            - { name: ibexa.rest.input.parser, mediaType: application/vnd.ez.api.internal.facetbuilder.Term }
 
     ezpublish_rest.input.parser.internal.facetbuilder.user:
         parent: ezpublish_rest.input.parser
         class: '%ezpublish_rest.input.parser.internal.facetbuilder.user.class%'
         tags:
-            - { name: ezpublish_rest.input.parser, mediaType: application/vnd.ez.api.internal.facetbuilder.User }
+            - { name: ibexa.rest.input.parser, mediaType: application/vnd.ez.api.internal.facetbuilder.User }
 
     # aggregation parsers
 
     Ibexa\Rest\Server\Input\Parser\Aggregation\Range\DateTimeRangeParser:
         parent: ezpublish_rest.input.parser
         tags:
-            - { name: ezpublish_rest.input.parser, mediaType: application/vnd.ez.api.internal.aggregation.range.DateTimeRange }
+            - { name: ibexa.rest.input.parser, mediaType: application/vnd.ez.api.internal.aggregation.range.DateTimeRange }
 
     Ibexa\Rest\Server\Input\Parser\Aggregation\Range\FloatRangeParser:
         parent: ezpublish_rest.input.parser
         tags:
-            - { name: ezpublish_rest.input.parser, mediaType: application/vnd.ez.api.internal.aggregation..range.FloatRange }
+            - { name: ibexa.rest.input.parser, mediaType: application/vnd.ez.api.internal.aggregation..range.FloatRange }
 
     Ibexa\Rest\Server\Input\Parser\Aggregation\Range\IntRangeParser:
         parent: ezpublish_rest.input.parser
         tags:
-            - { name: ezpublish_rest.input.parser, mediaType: application/vnd.ez.api.internal.aggregation.range.IntRange }
+            - { name: ibexa.rest.input.parser, mediaType: application/vnd.ez.api.internal.aggregation.range.IntRange }
 
     Ibexa\Rest\Server\Input\Parser\Aggregation\ContentTypeGroupTermAggregationParser:
         parent: ezpublish_rest.input.parser
         tags:
-            - { name: ezpublish_rest.input.parser, mediaType: application/vnd.ez.api.internal.aggregation.ContentTypeGroupTermAggregation }
+            - { name: ibexa.rest.input.parser, mediaType: application/vnd.ez.api.internal.aggregation.ContentTypeGroupTermAggregation }
 
     Ibexa\Rest\Server\Input\Parser\Aggregation\ContentTypeTermAggregationParser:
         parent: ezpublish_rest.input.parser
         tags:
-            - { name: ezpublish_rest.input.parser, mediaType: application/vnd.ez.api.internal.aggregation.ContentTypeTermAggregation }
+            - { name: ibexa.rest.input.parser, mediaType: application/vnd.ez.api.internal.aggregation.ContentTypeTermAggregation }
 
     Ibexa\Rest\Server\Input\Parser\Aggregation\DateMetadataRangeAggregationParser:
         parent: ezpublish_rest.input.parser
         tags:
-            - { name: ezpublish_rest.input.parser, mediaType: application/vnd.ez.api.internal.aggregation.DateMetadataRangeAggregation }
+            - { name: ibexa.rest.input.parser, mediaType: application/vnd.ez.api.internal.aggregation.DateMetadataRangeAggregation }
 
     Ibexa\Rest\Server\Input\Parser\Aggregation\Field\AuthorTermAggregationParser:
         parent: ezpublish_rest.input.parser
         tags:
-            - { name: ezpublish_rest.input.parser, mediaType: application/vnd.ez.api.internal.aggregation.AuthorTermAggregation }
+            - { name: ibexa.rest.input.parser, mediaType: application/vnd.ez.api.internal.aggregation.AuthorTermAggregation }
 
     Ibexa\Rest\Server\Input\Parser\Aggregation\Field\CheckboxTermAggregationParser:
         parent: ezpublish_rest.input.parser
         tags:
-            - { name: ezpublish_rest.input.parser, mediaType: application/vnd.ez.api.internal.aggregation.CheckboxTermAggregation }
+            - { name: ibexa.rest.input.parser, mediaType: application/vnd.ez.api.internal.aggregation.CheckboxTermAggregation }
 
     Ibexa\Rest\Server\Input\Parser\Aggregation\Field\CountryTermAggregationParser:
         parent: ezpublish_rest.input.parser
         tags:
-            - { name: ezpublish_rest.input.parser, mediaType: application/vnd.ez.api.internal.aggregation.CountryTermAggregation }
+            - { name: ibexa.rest.input.parser, mediaType: application/vnd.ez.api.internal.aggregation.CountryTermAggregation }
 
     Ibexa\Rest\Server\Input\Parser\Aggregation\Field\DateRangeAggregationParser:
         parent: ezpublish_rest.input.parser
         tags:
-            - { name: ezpublish_rest.input.parser, mediaType: application/vnd.ez.api.internal.aggregation.DateRangeAggregation }
+            - { name: ibexa.rest.input.parser, mediaType: application/vnd.ez.api.internal.aggregation.DateRangeAggregation }
 
     Ibexa\Rest\Server\Input\Parser\Aggregation\Field\DateTimeRangeAggregationParser:
         parent: ezpublish_rest.input.parser
         tags:
-            - { name: ezpublish_rest.input.parser, mediaType: application/vnd.ez.api.internal.aggregation.DateTimeRangeAggregation }
+            - { name: ibexa.rest.input.parser, mediaType: application/vnd.ez.api.internal.aggregation.DateTimeRangeAggregation }
 
     Ibexa\Rest\Server\Input\Parser\Aggregation\Field\FloatRangeAggregationParser:
         parent: ezpublish_rest.input.parser
         tags:
-            - { name: ezpublish_rest.input.parser, mediaType: application/vnd.ez.api.internal.aggregation.FloatRangeAggregation }
+            - { name: ibexa.rest.input.parser, mediaType: application/vnd.ez.api.internal.aggregation.FloatRangeAggregation }
 
     Ibexa\Rest\Server\Input\Parser\Aggregation\Field\FloatStatsAggregationParser:
         parent: ezpublish_rest.input.parser
         tags:
-            - { name: ezpublish_rest.input.parser, mediaType: application/vnd.ez.api.internal.aggregation.FloatStatsAggregation }
+            - { name: ibexa.rest.input.parser, mediaType: application/vnd.ez.api.internal.aggregation.FloatStatsAggregation }
 
     Ibexa\Rest\Server\Input\Parser\Aggregation\Field\IntegerRangeAggregationParser:
         parent: ezpublish_rest.input.parser
         tags:
-            - { name: ezpublish_rest.input.parser, mediaType: application/vnd.ez.api.internal.aggregation.IntegerRangeAggregation }
+            - { name: ibexa.rest.input.parser, mediaType: application/vnd.ez.api.internal.aggregation.IntegerRangeAggregation }
 
     Ibexa\Rest\Server\Input\Parser\Aggregation\Field\IntegerStatsAggregationParser:
         parent: ezpublish_rest.input.parser
         tags:
-            - { name: ezpublish_rest.input.parser, mediaType: application/vnd.ez.api.internal.aggregation.IntegerStatsAggregation }
+            - { name: ibexa.rest.input.parser, mediaType: application/vnd.ez.api.internal.aggregation.IntegerStatsAggregation }
 
     Ibexa\Rest\Server\Input\Parser\Aggregation\Field\KeywordTermAggregationParser:
         parent: ezpublish_rest.input.parser
         tags:
-            - { name: ezpublish_rest.input.parser, mediaType: application/vnd.ez.api.internal.aggregation.KeywordTermAggregation }
+            - { name: ibexa.rest.input.parser, mediaType: application/vnd.ez.api.internal.aggregation.KeywordTermAggregation }
 
     Ibexa\Rest\Server\Input\Parser\Aggregation\Field\SelectionTermAggregationParser:
         parent: ezpublish_rest.input.parser
         tags:
-            - { name: ezpublish_rest.input.parser, mediaType: application/vnd.ez.api.internal.aggregation.SelectionTermAggregation }
+            - { name: ibexa.rest.input.parser, mediaType: application/vnd.ez.api.internal.aggregation.SelectionTermAggregation }
 
     Ibexa\Rest\Server\Input\Parser\Aggregation\Field\TimeRangeAggregationParser:
         parent: ezpublish_rest.input.parser
         tags:
-            - { name: ezpublish_rest.input.parser, mediaType: application/vnd.ez.api.internal.aggregation.TimeRangeAggregation }
+            - { name: ibexa.rest.input.parser, mediaType: application/vnd.ez.api.internal.aggregation.TimeRangeAggregation }
 
     Ibexa\Rest\Server\Input\Parser\Aggregation\LanguageTermAggregationParser:
         parent: ezpublish_rest.input.parser
         tags:
-            - { name: ezpublish_rest.input.parser, mediaType: application/vnd.ez.api.internal.aggregation.LanguageTermAggregation }
+            - { name: ibexa.rest.input.parser, mediaType: application/vnd.ez.api.internal.aggregation.LanguageTermAggregation }
 
     Ibexa\Rest\Server\Input\Parser\Aggregation\ObjectStateTermAggregationParser:
         parent: ezpublish_rest.input.parser
         tags:
-            - { name: ezpublish_rest.input.parser, mediaType: application/vnd.ez.api.internal.aggregation.ObjectStateTermAggregation }
+            - { name: ibexa.rest.input.parser, mediaType: application/vnd.ez.api.internal.aggregation.ObjectStateTermAggregation }
 
     Ibexa\Rest\Server\Input\Parser\Aggregation\RawRangeAggregationParser:
         parent: ezpublish_rest.input.parser
         tags:
-            - { name: ezpublish_rest.input.parser, mediaType: application/vnd.ez.api.internal.aggregation.RawRangeAggregation }
+            - { name: ibexa.rest.input.parser, mediaType: application/vnd.ez.api.internal.aggregation.RawRangeAggregation }
 
     Ibexa\Rest\Server\Input\Parser\Aggregation\RawStatsAggregationParser:
         parent: ezpublish_rest.input.parser
         tags:
-            - { name: ezpublish_rest.input.parser, mediaType: application/vnd.ez.api.internal.aggregation.RawStatsAggregation }
+            - { name: ibexa.rest.input.parser, mediaType: application/vnd.ez.api.internal.aggregation.RawStatsAggregation }
 
     Ibexa\Rest\Server\Input\Parser\Aggregation\RawTermAggregationParser:
         parent: ezpublish_rest.input.parser
         tags:
-            - { name: ezpublish_rest.input.parser, mediaType: application/vnd.ez.api.internal.aggregation.RawTermAggregation }
+            - { name: ibexa.rest.input.parser, mediaType: application/vnd.ez.api.internal.aggregation.RawTermAggregation }
 
     Ibexa\Rest\Server\Input\Parser\Aggregation\SectionTermAggregationParser:
         parent: ezpublish_rest.input.parser
         tags:
-            - { name: ezpublish_rest.input.parser, mediaType: application/vnd.ez.api.internal.aggregation.SectionTermAggregation }
+            - { name: ibexa.rest.input.parser, mediaType: application/vnd.ez.api.internal.aggregation.SectionTermAggregation }
 
     Ibexa\Rest\Server\Input\Parser\Aggregation\Location\SubtreeTermAggregationParser:
         parent: ezpublish_rest.input.parser
         tags:
-            - { name: ezpublish_rest.input.parser, mediaType: application/vnd.ez.api.internal.aggregation.SubtreeTermAggregation }
+            - { name: ibexa.rest.input.parser, mediaType: application/vnd.ez.api.internal.aggregation.SubtreeTermAggregation }
 
     Ibexa\Rest\Server\Input\Parser\Aggregation\Location\LocationChildrenTermAggregationParser:
         parent: ezpublish_rest.input.parser
         tags:
-            - { name: ezpublish_rest.input.parser, mediaType: application/vnd.ez.api.internal.aggregation.LocationChildrenTermAggregation }
+            - { name: ibexa.rest.input.parser, mediaType: application/vnd.ez.api.internal.aggregation.LocationChildrenTermAggregation }
 
     Ibexa\Rest\Server\Input\Parser\Aggregation\UserMetadataTermAggregationParser:
         parent: ezpublish_rest.input.parser
         tags:
-            - { name: ezpublish_rest.input.parser, mediaType: application/vnd.ez.api.internal.aggregation.UserMetadataTermAggregation }
+            - { name: ibexa.rest.input.parser, mediaType: application/vnd.ez.api.internal.aggregation.UserMetadataTermAggregation }
 
     Ibexa\Rest\Server\Input\Parser\Aggregation\VisibilityTermAggregationParser:
         parent: ezpublish_rest.input.parser
         tags:
-            - { name: ezpublish_rest.input.parser, mediaType: application/vnd.ez.api.internal.aggregation.VisibilityTermAggregation }
+            - { name: ibexa.rest.input.parser, mediaType: application/vnd.ez.api.internal.aggregation.VisibilityTermAggregation }
 
     # role limitation parsers
 
@@ -877,7 +877,7 @@ services:
         parent: ezpublish_rest.input.parser
         class: "%ezpublish_rest.input.parser.internal.path_string_route_based_limitation.class%"
         tags:
-            - { name: ezpublish_rest.input.parser, mediaType: application/vnd.ez.api.internal.limitation.Subtree }
+            - { name: ibexa.rest.input.parser, mediaType: application/vnd.ez.api.internal.limitation.Subtree }
         arguments:
             - 'locationPath'
             - 'Ibexa\Contracts\Core\Repository\Values\User\Limitation\SubtreeLimitation'
@@ -886,7 +886,7 @@ services:
         parent: ezpublish_rest.input.parser
         class: "%ezpublish_rest.input.parser.internal.route_based_limitation.class%"
         tags:
-            - { name: ezpublish_rest.input.parser, mediaType: application/vnd.ez.api.internal.limitation.Section }
+            - { name: ibexa.rest.input.parser, mediaType: application/vnd.ez.api.internal.limitation.Section }
         arguments:
             - 'sectionId'
             - 'Ibexa\Contracts\Core\Repository\Values\User\Limitation\SectionLimitation'

--- a/src/bundle/Resources/config/services.yml
+++ b/src/bundle/Resources/config/services.yml
@@ -379,7 +379,7 @@ services:
     ### OUTPUT
 
     # Main REST output dispatcher
-    # Gets a <requestMatch> => output.visitor mapping with the ezpublish_rest.output.visitor tag.
+    # Gets a <requestMatch> => output.visitor mapping with the ibexa.rest.output.visitor tag.
     ezpublish_rest.output.visitor.dispatcher:
         class: "%ezpublish_rest.output.visitor.dispatcher.class%"
 
@@ -390,7 +390,7 @@ services:
             - "@ezpublish_rest.output.generator.json"
             - "@ezpublish_rest.output.value_object_visitor.dispatcher"
         tags:
-            - { name: ezpublish_rest.output.visitor, regexps: ezpublish_rest.output.visitor.json.regexps }
+            - { name: ibexa.rest.output.visitor, regexps: ezpublish_rest.output.visitor.json.regexps }
 
     ezpublish_rest.output.visitor.xml:
         class: "%ezpublish_rest.output.visitor.class%"
@@ -398,7 +398,7 @@ services:
             - "@ezpublish_rest.output.generator.xml"
             - "@ezpublish_rest.output.value_object_visitor.dispatcher"
         tags:
-            - { name: ezpublish_rest.output.visitor, regexps: ezpublish_rest.output.visitor.xml.regexps }
+            - { name: ibexa.rest.output.visitor, regexps: ezpublish_rest.output.visitor.xml.regexps }
 
     # format output generators
     ezpublish_rest.output.generator.xml:
@@ -428,7 +428,7 @@ services:
     ezpublish_rest.output.value_object_visitor.Exception.InvalidArgumentException:
         class: "%ezpublish_rest.output.value_object_visitor.Exception.InvalidArgumentException.class%"
         tags:
-            - { name: ezpublish_rest.output.value_object_visitor, type: \Ibexa\Contracts\Core\Repository\Exceptions\InvalidArgumentException }
+            - { name: ibexa.rest.output.value_object.visitor, type: \Ibexa\Contracts\Core\Repository\Exceptions\InvalidArgumentException }
 
     ezpublish_rest.input.dispatcher:
         class: "%ezpublish_rest.input.dispatcher.class%"
@@ -442,12 +442,12 @@ services:
     ezpublish_rest.input.handler.json:
         class: "%ezpublish_rest.input.handler.json.class%"
         tags:
-            - { name: ezpublish_rest.input.handler, format: json }
+            - { name: ibexa.rest.input.handler, format: json }
 
     ezpublish_rest.input.handler.xml:
         class: "%ezpublish_rest.input.handler.xml.class%"
         tags:
-            - { name: ezpublish_rest.input.handler, format: xml }
+            - { name: ibexa.rest.input.handler, format: xml }
 
     ezpublish_rest.templated_router:
         class: Ibexa\Bundle\Core\Routing\DefaultRouter

--- a/src/bundle/Resources/config/value_object_visitors.yml
+++ b/src/bundle/Resources/config/value_object_visitors.yml
@@ -140,205 +140,205 @@ services:
         class: "%ezpublish_rest.output.value_object_visitor.InvalidArgumentException.class%"
         arguments: [ "%kernel.debug%", "@translator" ]
         tags:
-            - { name: ezpublish_rest.output.value_object_visitor, type: Ibexa\Contracts\Core\Repository\Exceptions\InvalidArgumentException }
+            - { name: ibexa.rest.output.value_object.visitor, type: Ibexa\Contracts\Core\Repository\Exceptions\InvalidArgumentException }
 
     ezpublish_rest.output.value_object_visitor.NotFoundException:
         parent: ezpublish_rest.output.value_object_visitor.base
         class: "%ezpublish_rest.output.value_object_visitor.NotFoundException.class%"
         arguments: [ "%kernel.debug%", "@translator" ]
         tags:
-            - { name: ezpublish_rest.output.value_object_visitor, type: Ibexa\Contracts\Core\Repository\Exceptions\NotFoundException }
+            - { name: ibexa.rest.output.value_object.visitor, type: Ibexa\Contracts\Core\Repository\Exceptions\NotFoundException }
 
     ezpublish_rest.output.value_object_visitor.UnauthorizedException:
         parent: ezpublish_rest.output.value_object_visitor.base
         class: "%ezpublish_rest.output.value_object_visitor.UnauthorizedException.class%"
         arguments: [ "%kernel.debug%", "@translator" ]
         tags:
-            - { name: ezpublish_rest.output.value_object_visitor, type: Ibexa\Contracts\Core\Repository\Exceptions\UnauthorizedException }
+            - { name: ibexa.rest.output.value_object.visitor, type: Ibexa\Contracts\Core\Repository\Exceptions\UnauthorizedException }
 
     ezpublish_rest.output.value_object_visitor.BadStateException:
         parent: ezpublish_rest.output.value_object_visitor.base
         class: "%ezpublish_rest.output.value_object_visitor.BadStateException.class%"
         arguments: [ "%kernel.debug%", "@translator" ]
         tags:
-            - { name: ezpublish_rest.output.value_object_visitor, type: Ibexa\Contracts\Core\Repository\Exceptions\BadStateException }
+            - { name: ibexa.rest.output.value_object.visitor, type: Ibexa\Contracts\Core\Repository\Exceptions\BadStateException }
 
     ezpublish_rest.output.value_object_visitor.BadRequestException:
         parent: ezpublish_rest.output.value_object_visitor.base
         class: "%ezpublish_rest.output.value_object_visitor.BadRequestException.class%"
         arguments: [ "%kernel.debug%", "@translator" ]
         tags:
-            - { name: ezpublish_rest.output.value_object_visitor, type: Ibexa\Rest\Server\Exceptions\BadRequestException }
-            - { name: ezpublish_rest.output.value_object_visitor, type: Ibexa\Contracts\Rest\Exceptions\Parser }
+            - { name: ibexa.rest.output.value_object.visitor, type: Ibexa\Rest\Server\Exceptions\BadRequestException }
+            - { name: ibexa.rest.output.value_object.visitor, type: Ibexa\Contracts\Rest\Exceptions\Parser }
 
     ezpublish_rest.output.value_object_visitor.ContentFieldValidationException:
         parent: ezpublish_rest.output.value_object_visitor.BadRequestException
         class: "%ezpublish_rest.output.value_object_visitor.ContentFieldValidationException.class%"
         arguments: [ "%kernel.debug%", "@translator" ]
         tags:
-            - { name: ezpublish_rest.output.value_object_visitor, type: Ibexa\Rest\Server\Exceptions\ContentFieldValidationException }
+            - {  name: ibexa.rest.output.value_object.visitor, type: Ibexa\Rest\Server\Exceptions\ContentFieldValidationException }
 
     ezpublish_rest.output.value_object_visitor.ForbiddenException:
         parent: ezpublish_rest.output.value_object_visitor.base
         class: "%ezpublish_rest.output.value_object_visitor.ForbiddenException.class%"
         arguments: [ "%kernel.debug%", "@translator" ]
         tags:
-            - { name: ezpublish_rest.output.value_object_visitor, type: Ibexa\Rest\Server\Exceptions\ForbiddenException }
+            - { name: ibexa.rest.output.value_object.visitor, type: Ibexa\Rest\Server\Exceptions\ForbiddenException }
 
     ezpublish_rest.output.value_object_visitor.NotImplementedException:
         parent: ezpublish_rest.output.value_object_visitor.base
         class: "%ezpublish_rest.output.value_object_visitor.NotImplementedException.class%"
         arguments: [ "%kernel.debug%", "@translator" ]
         tags:
-            - { name: ezpublish_rest.output.value_object_visitor, type: Ibexa\Contracts\Core\Repository\Exceptions\NotImplementedException }
+            - { name: ibexa.rest.output.value_object.visitor, type: Ibexa\Contracts\Core\Repository\Exceptions\NotImplementedException }
 
     ezpublish_rest.output.value_object_visitor.Exception:
         parent: ezpublish_rest.output.value_object_visitor.base
         class: "%ezpublish_rest.output.value_object_visitor.Exception.class%"
         arguments: [ "%kernel.debug%", "@translator" ]
         tags:
-            - { name: ezpublish_rest.output.value_object_visitor, type: Exception }
+            - { name: ibexa.rest.output.value_object.visitor, type: Exception }
 
     Ibexa\Rest\Server\Output\ValueObjectVisitor\HttpException:
         parent: ezpublish_rest.output.value_object_visitor.base
         arguments: [ "%kernel.debug%", "@translator" ]
         tags:
-            - { name: ezpublish_rest.output.value_object_visitor, type: Symfony\Component\HttpKernel\Exception\HttpException }
+            - { name: ibexa.rest.output.value_object.visitor, type: Symfony\Component\HttpKernel\Exception\HttpException }
 
     # Language
     ezpublish_rest.output.value_object_visitor.Language:
         parent: ezpublish_rest.output.value_object_visitor.base
         class: Ibexa\Rest\Server\Output\ValueObjectVisitor\Language
         tags:
-            - { name: ezpublish_rest.output.value_object_visitor, type: Ibexa\Contracts\Core\Repository\Values\Content\Language }
+            - { name: ibexa.rest.output.value_object.visitor, type: Ibexa\Contracts\Core\Repository\Values\Content\Language }
 
     # Section
     ezpublish_rest.output.value_object_visitor.SectionList:
         parent: ezpublish_rest.output.value_object_visitor.base
         class: "%ezpublish_rest.output.value_object_visitor.SectionList.class%"
         tags:
-            - { name: ezpublish_rest.output.value_object_visitor, type: Ibexa\Rest\Server\Values\SectionList }
+            - { name: ibexa.rest.output.value_object.visitor, type: Ibexa\Rest\Server\Values\SectionList }
 
     ezpublish_rest.output.value_object_visitor.CreatedSection:
         parent: ezpublish_rest.output.value_object_visitor.base
         class: "%ezpublish_rest.output.value_object_visitor.CreatedSection.class%"
         tags:
-            - { name: ezpublish_rest.output.value_object_visitor, type: Ibexa\Rest\Server\Values\CreatedSection }
+            - { name: ibexa.rest.output.value_object.visitor, type: Ibexa\Rest\Server\Values\CreatedSection }
 
     ezpublish_rest.output.value_object_visitor.Section:
         parent: ezpublish_rest.output.value_object_visitor.base
         class: "%ezpublish_rest.output.value_object_visitor.Section.class%"
         tags:
-            - { name: ezpublish_rest.output.value_object_visitor, type: Ibexa\Contracts\Core\Repository\Values\Content\Section }
+            - { name: ibexa.rest.output.value_object.visitor, type: Ibexa\Contracts\Core\Repository\Values\Content\Section }
 
     # URLWildcard
     ezpublish_rest.output.value_object_visitor.URLWildcardList:
         parent: ezpublish_rest.output.value_object_visitor.base
         class: "%ezpublish_rest.output.value_object_visitor.URLWildcardList.class%"
         tags:
-            - { name: ezpublish_rest.output.value_object_visitor, type: Ibexa\Rest\Server\Values\URLWildcardList }
+            - { name: ibexa.rest.output.value_object.visitor, type: Ibexa\Rest\Server\Values\URLWildcardList }
 
     ezpublish_rest.output.value_object_visitor.URLWildcard:
         parent: ezpublish_rest.output.value_object_visitor.base
         class: "%ezpublish_rest.output.value_object_visitor.URLWildcard.class%"
         tags:
-            - { name: ezpublish_rest.output.value_object_visitor, type: Ibexa\Contracts\Core\Repository\Values\Content\URLWildcard }
+            - { name: ibexa.rest.output.value_object.visitor, type: Ibexa\Contracts\Core\Repository\Values\Content\URLWildcard }
 
     ezpublish_rest.output.value_object_visitor.CreatedURLWildcard:
         parent: ezpublish_rest.output.value_object_visitor.base
         class: "%ezpublish_rest.output.value_object_visitor.CreatedURLWildcard.class%"
         tags:
-            - { name: ezpublish_rest.output.value_object_visitor, type: Ibexa\Rest\Server\Values\CreatedURLWildcard }
+            - { name: ibexa.rest.output.value_object.visitor, type: Ibexa\Rest\Server\Values\CreatedURLWildcard }
 
     # URLAlias
     ezpublish_rest.output.value_object_visitor.URLAliasList:
         parent: ezpublish_rest.output.value_object_visitor.base
         class: "%ezpublish_rest.output.value_object_visitor.URLAliasList.class%"
         tags:
-            - { name: ezpublish_rest.output.value_object_visitor, type: Ibexa\Rest\Server\Values\URLAliasList }
+            - { name: ibexa.rest.output.value_object.visitor, type: Ibexa\Rest\Server\Values\URLAliasList }
 
     ezpublish_rest.output.value_object_visitor.URLAliasRefList:
         parent: ezpublish_rest.output.value_object_visitor.base
         class: "%ezpublish_rest.output.value_object_visitor.URLAliasRefList.class%"
         tags:
-            - { name: ezpublish_rest.output.value_object_visitor, type: Ibexa\Rest\Server\Values\URLAliasRefList }
+            - { name: ibexa.rest.output.value_object.visitor, type: Ibexa\Rest\Server\Values\URLAliasRefList }
 
     ezpublish_rest.output.value_object_visitor.URLAlias:
         parent: ezpublish_rest.output.value_object_visitor.base
         class: "%ezpublish_rest.output.value_object_visitor.URLAlias.class%"
         tags:
-            - { name: ezpublish_rest.output.value_object_visitor, type: Ibexa\Contracts\Core\Repository\Values\Content\URLAlias }
+            - { name: ibexa.rest.output.value_object.visitor, type: Ibexa\Contracts\Core\Repository\Values\Content\URLAlias }
 
     ezpublish_rest.output.value_object_visitor.CreatedURLAlias:
         parent: ezpublish_rest.output.value_object_visitor.base
         class: "%ezpublish_rest.output.value_object_visitor.CreatedURLAlias.class%"
         tags:
-            - { name: ezpublish_rest.output.value_object_visitor, type: Ibexa\Rest\Server\Values\CreatedURLAlias }
+            - { name: ibexa.rest.output.value_object.visitor, type: Ibexa\Rest\Server\Values\CreatedURLAlias }
 
     # Content
     ezpublish_rest.output.value_object_visitor.Author:
         parent: ezpublish_rest.output.value_object_visitor.base
         class: Ibexa\Rest\Server\Output\ValueObjectVisitor\Author
         tags:
-            - { name: ezpublish_rest.output.value_object_visitor, type: Ibexa\Core\FieldType\Author\Author }
+            - { name: ibexa.rest.output.value_object.visitor, type: Ibexa\Core\FieldType\Author\Author }
 
     ezpublish_rest.output.value_object_visitor.ContentList:
         parent: ezpublish_rest.output.value_object_visitor.base
         class: "%ezpublish_rest.output.value_object_visitor.ContentList.class%"
         tags:
-            - { name: ezpublish_rest.output.value_object_visitor, type: Ibexa\Rest\Server\Values\ContentList }
+            - { name: ibexa.rest.output.value_object.visitor, type: Ibexa\Rest\Server\Values\ContentList }
 
     ezpublish_rest.output.value_object_visitor.RestContent:
         parent: ezpublish_rest.output.value_object_visitor.base
         class: "%ezpublish_rest.output.value_object_visitor.RestContent.class%"
         arguments: ['@ezpublish.translation_helper']
         tags:
-            - { name: ezpublish_rest.output.value_object_visitor, type: Ibexa\Rest\Server\Values\RestContent }
+            - { name: ibexa.rest.output.value_object.visitor, type: Ibexa\Rest\Server\Values\RestContent }
 
     ezpublish_rest.output.value_object_visitor.CreatedContent:
         parent: ezpublish_rest.output.value_object_visitor.base
         class: "%ezpublish_rest.output.value_object_visitor.CreatedContent.class%"
         arguments: ['@ezpublish.translation_helper']
         tags:
-            - { name: ezpublish_rest.output.value_object_visitor, type: Ibexa\Rest\Server\Values\CreatedContent }
+            - { name: ibexa.rest.output.value_object.visitor, type: Ibexa\Rest\Server\Values\CreatedContent }
 
     ezpublish_rest.output.value_object_visitor.VersionList:
         parent: ezpublish_rest.output.value_object_visitor.base
         class: "%ezpublish_rest.output.value_object_visitor.VersionList.class%"
         tags:
-            - { name: ezpublish_rest.output.value_object_visitor, type: Ibexa\Rest\Server\Values\VersionList }
+            - { name: ibexa.rest.output.value_object.visitor, type: Ibexa\Rest\Server\Values\VersionList }
 
     ezpublish_rest.output.value_object_visitor.CreatedVersion:
         parent: ezpublish_rest.output.value_object_visitor.base
         class: "%ezpublish_rest.output.value_object_visitor.CreatedVersion.class%"
         arguments: [ "@ezpublish_rest.field_type_serializer" ]
         tags:
-            - { name: ezpublish_rest.output.value_object_visitor, type: Ibexa\Rest\Server\Values\CreatedVersion }
+            - { name: ibexa.rest.output.value_object.visitor, type: Ibexa\Rest\Server\Values\CreatedVersion }
 
     ezpublish_rest.output.value_object_visitor.VersionInfo:
         parent: ezpublish_rest.output.value_object_visitor.base
         class: "%ezpublish_rest.output.value_object_visitor.VersionInfo.class%"
         tags:
-            - { name: ezpublish_rest.output.value_object_visitor, type: Ibexa\Contracts\Core\Repository\Values\Content\VersionInfo }
+            - { name: ibexa.rest.output.value_object.visitor, type: Ibexa\Contracts\Core\Repository\Values\Content\VersionInfo }
 
     ezpublish_rest.output.value_object_visitor.ImageVariation:
         parent: ezpublish_rest.output.value_object_visitor.base
         class: "%ezpublish_rest.output.value_object_visitor.ImageVariation.class%"
         tags:
-            - { name: ezpublish_rest.output.value_object_visitor, type: Ibexa\Contracts\Core\Variation\Values\ImageVariation }
+            - { name: ibexa.rest.output.value_object.visitor, type: Ibexa\Contracts\Core\Variation\Values\ImageVariation }
 
     ezpublish_rest.output.value_object_visitor.Version:
         parent: ezpublish_rest.output.value_object_visitor.base
         class: "%ezpublish_rest.output.value_object_visitor.Version.class%"
         arguments: [ "@ezpublish_rest.field_type_serializer"  ]
         tags:
-            - { name: ezpublish_rest.output.value_object_visitor, type: Ibexa\Rest\Server\Values\Version }
+            - { name: ibexa.rest.output.value_object.visitor, type: Ibexa\Rest\Server\Values\Version }
 
     ezpublish_rest.output.value_object_visitor.VersionTranslationInfo:
         parent: ezpublish_rest.output.value_object_visitor.base
         class: "%ezpublish_rest.output.value_object_visitor.VersionTranslationInfo.class%"
         tags:
-            - { name: ezpublish_rest.output.value_object_visitor, type: Ibexa\Rest\Server\Values\VersionTranslationInfo }
+            - { name: ibexa.rest.output.value_object.visitor, type: Ibexa\Rest\Server\Values\VersionTranslationInfo }
 
     # UserGroup
     ezpublish_rest.output.value_object_visitor.UserGroup:
@@ -347,50 +347,50 @@ services:
         arguments:
             $contentService: '@ezpublish.api.service.content'
         tags:
-            - { name: ezpublish_rest.output.value_object_visitor, type: Ibexa\Contracts\Core\Repository\Values\User\UserGroup }
+            - { name: ibexa.rest.output.value_object.visitor, type: Ibexa\Contracts\Core\Repository\Values\User\UserGroup }
 
     ezpublish_rest.output.value_object_visitor.RestUserGroup:
         parent: ezpublish_rest.output.value_object_visitor.base
         class: "%ezpublish_rest.output.value_object_visitor.RestUserGroup.class%"
         tags:
-            - { name: ezpublish_rest.output.value_object_visitor, type: Ibexa\Rest\Server\Values\RestUserGroup }
+            - { name: ibexa.rest.output.value_object.visitor, type: Ibexa\Rest\Server\Values\RestUserGroup }
 
     ezpublish_rest.output.value_object_visitor.CreatedUserGroup:
         parent: ezpublish_rest.output.value_object_visitor.base
         class: "%ezpublish_rest.output.value_object_visitor.CreatedUserGroup.class%"
         tags:
-            - { name: ezpublish_rest.output.value_object_visitor, type: Ibexa\Rest\Server\Values\CreatedUserGroup }
+            - { name: ibexa.rest.output.value_object.visitor, type: Ibexa\Rest\Server\Values\CreatedUserGroup }
 
     ezpublish_rest.output.value_object_visitor.UserGroupList:
         parent: ezpublish_rest.output.value_object_visitor.base
         class: "%ezpublish_rest.output.value_object_visitor.UserGroupList.class%"
         tags:
-            - { name: ezpublish_rest.output.value_object_visitor, type: Ibexa\Rest\Server\Values\UserGroupList }
+            - { name: ibexa.rest.output.value_object.visitor, type: Ibexa\Rest\Server\Values\UserGroupList }
 
     ezpublish_rest.output.value_object_visitor.UserGroupRefList:
         parent: ezpublish_rest.output.value_object_visitor.base
         class: "%ezpublish_rest.output.value_object_visitor.UserGroupRefList.class%"
         tags:
-            - { name: ezpublish_rest.output.value_object_visitor, type: Ibexa\Rest\Server\Values\UserGroupRefList }
+            - { name: ibexa.rest.output.value_object.visitor, type: Ibexa\Rest\Server\Values\UserGroupRefList }
 
     # User
     ezpublish_rest.output.value_object_visitor.UserList:
         parent: ezpublish_rest.output.value_object_visitor.base
         class: "%ezpublish_rest.output.value_object_visitor.UserList.class%"
         tags:
-            - { name: ezpublish_rest.output.value_object_visitor, type: Ibexa\Rest\Server\Values\UserList }
+            - { name: ibexa.rest.output.value_object.visitor, type: Ibexa\Rest\Server\Values\UserList }
 
     ezpublish_rest.output.value_object_visitor.UserRefList:
         parent: ezpublish_rest.output.value_object_visitor.base
         class: "%ezpublish_rest.output.value_object_visitor.UserRefList.class%"
         tags:
-            - { name: ezpublish_rest.output.value_object_visitor, type: Ibexa\Rest\Server\Values\UserRefList }
+            - { name: ibexa.rest.output.value_object.visitor, type: Ibexa\Rest\Server\Values\UserRefList }
 
     ezpublish_rest.output.value_object_visitor.CreatedUser:
         parent: ezpublish_rest.output.value_object_visitor.base
         class: "%ezpublish_rest.output.value_object_visitor.CreatedUser.class%"
         tags:
-            - { name: ezpublish_rest.output.value_object_visitor, type: Ibexa\Rest\Server\Values\CreatedUser }
+            - { name: ibexa.rest.output.value_object.visitor, type: Ibexa\Rest\Server\Values\CreatedUser }
 
     ezpublish_rest.output.value_object_visitor.User:
         parent: ezpublish_rest.output.value_object_visitor.base
@@ -398,206 +398,206 @@ services:
         arguments:
             $contentService: '@ezpublish.api.service.content'
         tags:
-            - { name: ezpublish_rest.output.value_object_visitor, type: Ibexa\Contracts\Core\Repository\Values\User\User }
+            - { name: ibexa.rest.output.value_object.visitor, type: Ibexa\Contracts\Core\Repository\Values\User\User }
 
     ezpublish_rest.output.value_object_visitor.RestUser:
         parent: ezpublish_rest.output.value_object_visitor.base
         class: "%ezpublish_rest.output.value_object_visitor.RestUser.class%"
         tags:
-            - { name: ezpublish_rest.output.value_object_visitor, type: Ibexa\Rest\Server\Values\RestUser }
+            - { name: ibexa.rest.output.value_object.visitor, type: Ibexa\Rest\Server\Values\RestUser }
 
     ezpublish_rest.output.value_object_visitor.UserSession:
         parent: ezpublish_rest.output.value_object_visitor.base
         class: "%ezpublish_rest.output.value_object_visitor.UserSession.class%"
         tags:
-            - { name: ezpublish_rest.output.value_object_visitor, type: Ibexa\Rest\Server\Values\UserSession }
+            - { name: ibexa.rest.output.value_object.visitor, type: Ibexa\Rest\Server\Values\UserSession }
 
     ezpublish_rest.output.value_object_visitor.UserSessionDeleted:
         parent: ezpublish_rest.output.value_object_visitor.base
         class: "%ezpublish_rest.output.value_object_visitor.UserSessionDeleted.class%"
         tags:
-            - { name: ezpublish_rest.output.value_object_visitor, type: Ibexa\Rest\Server\Values\DeletedUserSession }
+            - { name: ibexa.rest.output.value_object.visitor, type: Ibexa\Rest\Server\Values\DeletedUserSession }
 
     Ibexa\Rest\Server\Output\ValueObjectVisitor\JWT:
         parent: ezpublish_rest.output.value_object_visitor.base
         tags:
-            - { name: ezpublish_rest.output.value_object_visitor, type: Ibexa\Rest\Server\Values\JWT }
+            - { name: ibexa.rest.output.value_object.visitor, type: Ibexa\Rest\Server\Values\JWT }
 
     # ContentType
     ezpublish_rest.output.value_object_visitor.ContentType:
         parent: ezpublish_rest.output.value_object_visitor.base
         class: Ibexa\Rest\Server\Output\ValueObjectVisitor\ContentType
         tags:
-            - { name: ezpublish_rest.output.value_object_visitor, type: Ibexa\Contracts\Core\Repository\Values\ContentType\ContentType }
+            - { name: ibexa.rest.output.value_object.visitor, type: Ibexa\Contracts\Core\Repository\Values\ContentType\ContentType }
 
     ezpublish_rest.output.value_object_visitor.RestContentType:
         parent: ezpublish_rest.output.value_object_visitor.base
         class: "%ezpublish_rest.output.value_object_visitor.RestContentType.class%"
         tags:
-            - { name: ezpublish_rest.output.value_object_visitor, type: Ibexa\Rest\Server\Values\RestContentType }
+            - { name: ibexa.rest.output.value_object.visitor, type: Ibexa\Rest\Server\Values\RestContentType }
 
     ezpublish_rest.output.value_object_visitor.CreatedContentType:
         parent: ezpublish_rest.output.value_object_visitor.base
         class: "%ezpublish_rest.output.value_object_visitor.CreatedContentType.class%"
         tags:
-            - { name: ezpublish_rest.output.value_object_visitor, type: Ibexa\Rest\Server\Values\CreatedContentType }
+            - { name: ibexa.rest.output.value_object.visitor, type: Ibexa\Rest\Server\Values\CreatedContentType }
 
     ezpublish_rest.output.value_object_visitor.ContentTypeList:
         parent: ezpublish_rest.output.value_object_visitor.base
         class: "%ezpublish_rest.output.value_object_visitor.ContentTypeList.class%"
         tags:
-            - { name: ezpublish_rest.output.value_object_visitor, type: Ibexa\Rest\Server\Values\ContentTypeList }
+            - { name: ibexa.rest.output.value_object.visitor, type: Ibexa\Rest\Server\Values\ContentTypeList }
 
     ezpublish_rest.output.value_object_visitor.ContentTypeInfoList:
         parent: ezpublish_rest.output.value_object_visitor.base
         class: "%ezpublish_rest.output.value_object_visitor.ContentTypeInfoList.class%"
         tags:
-            - { name: ezpublish_rest.output.value_object_visitor, type: Ibexa\Rest\Server\Values\ContentTypeInfoList }
+            - { name: ibexa.rest.output.value_object.visitor, type: Ibexa\Rest\Server\Values\ContentTypeInfoList }
 
     ezpublish_rest.output.value_object_visitor.ContentTypeGroup:
         parent: ezpublish_rest.output.value_object_visitor.base
         class: "%ezpublish_rest.output.value_object_visitor.ContentTypeGroup.class%"
         tags:
-            - { name: ezpublish_rest.output.value_object_visitor, type: Ibexa\Contracts\Core\Repository\Values\ContentType\ContentTypeGroup }
+            - { name: ibexa.rest.output.value_object.visitor, type: Ibexa\Contracts\Core\Repository\Values\ContentType\ContentTypeGroup }
 
     ezpublish_rest.output.value_object_visitor.CreatedContentTypeGroup:
         parent: ezpublish_rest.output.value_object_visitor.base
         class: "%ezpublish_rest.output.value_object_visitor.CreatedContentTypeGroup.class%"
         tags:
-            - { name: ezpublish_rest.output.value_object_visitor, type: Ibexa\Rest\Server\Values\CreatedContentTypeGroup }
+            - { name: ibexa.rest.output.value_object.visitor, type: Ibexa\Rest\Server\Values\CreatedContentTypeGroup }
 
     ezpublish_rest.output.value_object_visitor.ContentTypeGroupList:
         parent: ezpublish_rest.output.value_object_visitor.base
         class: "%ezpublish_rest.output.value_object_visitor.ContentTypeGroupList.class%"
         tags:
-            - { name: ezpublish_rest.output.value_object_visitor, type: Ibexa\Rest\Server\Values\ContentTypeGroupList }
+            - { name: ibexa.rest.output.value_object.visitor, type: Ibexa\Rest\Server\Values\ContentTypeGroupList }
 
     ezpublish_rest.output.value_object_visitor.ContentTypeGroupRefList:
         parent: ezpublish_rest.output.value_object_visitor.base
         class: "%ezpublish_rest.output.value_object_visitor.ContentTypeGroupRefList.class%"
         tags:
-            - { name: ezpublish_rest.output.value_object_visitor, type: Ibexa\Rest\Server\Values\ContentTypeGroupRefList }
+            - { name: ibexa.rest.output.value_object.visitor, type: Ibexa\Rest\Server\Values\ContentTypeGroupRefList }
 
     ezpublish_rest.output.value_object_visitor.FieldDefinitionList:
         parent: ezpublish_rest.output.value_object_visitor.base
         class: "%ezpublish_rest.output.value_object_visitor.FieldDefinitionList.class%"
         tags:
-            - { name: ezpublish_rest.output.value_object_visitor, type: Ibexa\Rest\Server\Values\FieldDefinitionList }
+            - { name: ibexa.rest.output.value_object.visitor, type: Ibexa\Rest\Server\Values\FieldDefinitionList }
 
     ezpublish_rest.output.value_object_visitor.CreatedFieldDefinition:
         parent: ezpublish_rest.output.value_object_visitor.base
         class: "%ezpublish_rest.output.value_object_visitor.CreatedFieldDefinition.class%"
         arguments: [ "@ezpublish_rest.field_type_serializer"  ]
         tags:
-            - { name: ezpublish_rest.output.value_object_visitor, type: Ibexa\Rest\Server\Values\CreatedFieldDefinition }
+            - { name: ibexa.rest.output.value_object.visitor, type: Ibexa\Rest\Server\Values\CreatedFieldDefinition }
 
     ezpublish_rest.output.value_object_visitor.RestFieldDefinition:
         parent: ezpublish_rest.output.value_object_visitor.base
         class: "%ezpublish_rest.output.value_object_visitor.RestFieldDefinition.class%"
         arguments: [ "@ezpublish_rest.field_type_serializer"  ]
         tags:
-            - { name: ezpublish_rest.output.value_object_visitor, type: Ibexa\Rest\Server\Values\RestFieldDefinition }
+            - { name: ibexa.rest.output.value_object.visitor, type: Ibexa\Rest\Server\Values\RestFieldDefinition }
 
     # Relation
     ezpublish_rest.output.value_object_visitor.RelationList:
         parent: ezpublish_rest.output.value_object_visitor.base
         class: "%ezpublish_rest.output.value_object_visitor.RelationList.class%"
         tags:
-            - { name: ezpublish_rest.output.value_object_visitor, type: Ibexa\Rest\Server\Values\RelationList }
+            - { name: ibexa.rest.output.value_object.visitor, type: Ibexa\Rest\Server\Values\RelationList }
 
     ezpublish_rest.output.value_object_visitor.RestRelation:
         parent: ezpublish_rest.output.value_object_visitor.base
         class: "%ezpublish_rest.output.value_object_visitor.RestRelation.class%"
         tags:
-            - { name: ezpublish_rest.output.value_object_visitor, type: Ibexa\Rest\Server\Values\RestRelation }
+            - { name: ibexa.rest.output.value_object.visitor, type: Ibexa\Rest\Server\Values\RestRelation }
 
     ezpublish_rest.output.value_object_visitor.CreatedRelation:
         parent: ezpublish_rest.output.value_object_visitor.base
         class: "%ezpublish_rest.output.value_object_visitor.CreatedRelation.class%"
         tags:
-            - { name: ezpublish_rest.output.value_object_visitor, type: Ibexa\Rest\Server\Values\CreatedRelation }
+            - { name: ibexa.rest.output.value_object.visitor, type: Ibexa\Rest\Server\Values\CreatedRelation }
 
     # Role
     ezpublish_rest.output.value_object_visitor.RoleList:
         parent: ezpublish_rest.output.value_object_visitor.base
         class: "%ezpublish_rest.output.value_object_visitor.RoleList.class%"
         tags:
-            - { name: ezpublish_rest.output.value_object_visitor, type: Ibexa\Rest\Server\Values\RoleList }
+            - { name: ibexa.rest.output.value_object.visitor, type: Ibexa\Rest\Server\Values\RoleList }
 
     ezpublish_rest.output.value_object_visitor.CreatedRole:
         parent: ezpublish_rest.output.value_object_visitor.base
         class: "%ezpublish_rest.output.value_object_visitor.CreatedRole.class%"
         tags:
-            - { name: ezpublish_rest.output.value_object_visitor, type: Ibexa\Rest\Server\Values\CreatedRole }
+            - { name: ibexa.rest.output.value_object.visitor, type: Ibexa\Rest\Server\Values\CreatedRole }
 
     ezpublish_rest.output.value_object_visitor.PublishedRole:
         parent: ezpublish_rest.output.value_object_visitor.base
         class: "%ezpublish_rest.output.value_object_visitor.PublishedRole.class%"
         tags:
-            - { name: ezpublish_rest.output.value_object_visitor, type: Ibexa\Rest\Server\Values\PublishedRole }
+            - { name: ibexa.rest.output.value_object.visitor, type: Ibexa\Rest\Server\Values\PublishedRole }
 
     ezpublish_rest.output.value_object_visitor.Role:
         parent: ezpublish_rest.output.value_object_visitor.base
         class: "%ezpublish_rest.output.value_object_visitor.Role.class%"
         tags:
-            - { name: ezpublish_rest.output.value_object_visitor, type: Ibexa\Contracts\Core\Repository\Values\User\Role }
-            - { name: ezpublish_rest.output.value_object_visitor, type: Ibexa\Contracts\Core\Repository\Values\User\RoleDraft }
+            - { name: ibexa.rest.output.value_object.visitor, type: Ibexa\Contracts\Core\Repository\Values\User\Role }
+            - { name: ibexa.rest.output.value_object.visitor, type: Ibexa\Contracts\Core\Repository\Values\User\RoleDraft }
 
     ezpublish_rest.output.value_object_visitor.Policy:
         parent: ezpublish_rest.output.value_object_visitor.base
         class: "%ezpublish_rest.output.value_object_visitor.Policy.class%"
         tags:
-            - { name: ezpublish_rest.output.value_object_visitor, type: Ibexa\Contracts\Core\Repository\Values\User\Policy }
-            - { name: ezpublish_rest.output.value_object_visitor, type: Ibexa\Contracts\Core\Repository\Values\User\PolicyDraft }
+            - { name: ibexa.rest.output.value_object.visitor, type: Ibexa\Contracts\Core\Repository\Values\User\Policy }
+            - { name: ibexa.rest.output.value_object.visitor, type: Ibexa\Contracts\Core\Repository\Values\User\PolicyDraft }
 
     ezpublish_rest.output.value_object_visitor.CreatedPolicy:
         parent: ezpublish_rest.output.value_object_visitor.base
         class: "%ezpublish_rest.output.value_object_visitor.CreatedPolicy.class%"
         tags:
-            - { name: ezpublish_rest.output.value_object_visitor, type: Ibexa\Rest\Server\Values\CreatedPolicy }
+            - { name: ibexa.rest.output.value_object.visitor, type: Ibexa\Rest\Server\Values\CreatedPolicy }
 
     ezpublish_rest.output.value_object_visitor.PolicyList:
         parent: ezpublish_rest.output.value_object_visitor.base
         class: "%ezpublish_rest.output.value_object_visitor.PolicyList.class%"
         tags:
-            - { name: ezpublish_rest.output.value_object_visitor, type: Ibexa\Rest\Server\Values\PolicyList }
+            - { name: ibexa.rest.output.value_object.visitor, type: Ibexa\Rest\Server\Values\PolicyList }
 
     ezpublish_rest.output.value_object_visitor.RoleAssignmentList:
         parent: ezpublish_rest.output.value_object_visitor.base
         class: "%ezpublish_rest.output.value_object_visitor.RoleAssignmentList.class%"
         tags:
-            - { name: ezpublish_rest.output.value_object_visitor, type: Ibexa\Rest\Server\Values\RoleAssignmentList }
+            - { name: ibexa.rest.output.value_object.visitor, type: Ibexa\Rest\Server\Values\RoleAssignmentList }
 
     ezpublish_rest.output.value_object_visitor.RestUserRoleAssignment:
         parent: ezpublish_rest.output.value_object_visitor.base
         class: "%ezpublish_rest.output.value_object_visitor.RestUserRoleAssignment.class%"
         tags:
-            - { name: ezpublish_rest.output.value_object_visitor, type: Ibexa\Rest\Server\Values\RestUserRoleAssignment }
+            - { name: ibexa.rest.output.value_object.visitor, type: Ibexa\Rest\Server\Values\RestUserRoleAssignment }
 
     ezpublish_rest.output.value_object_visitor.RestUserGroupRoleAssignment:
         parent: ezpublish_rest.output.value_object_visitor.base
         class: "%ezpublish_rest.output.value_object_visitor.RestUserGroupRoleAssignment.class%"
         tags:
-            - { name: ezpublish_rest.output.value_object_visitor, type: Ibexa\Rest\Server\Values\RestUserGroupRoleAssignment }
+            - { name: ibexa.rest.output.value_object.visitor, type: Ibexa\Rest\Server\Values\RestUserGroupRoleAssignment }
 
     # Location
     ezpublish_rest.output.value_object_visitor.CreatedLocation:
         parent: ezpublish_rest.output.value_object_visitor.base
         class: "%ezpublish_rest.output.value_object_visitor.CreatedLocation.class%"
         tags:
-            - { name: ezpublish_rest.output.value_object_visitor, type: Ibexa\Rest\Server\Values\CreatedLocation }
+            - { name: ibexa.rest.output.value_object.visitor, type: Ibexa\Rest\Server\Values\CreatedLocation }
 
     ezpublish_rest.output.value_object_visitor.RestLocation:
         parent: ezpublish_rest.output.value_object_visitor.base
         class: "%ezpublish_rest.output.value_object_visitor.RestLocation.class%"
         tags:
-            - { name: ezpublish_rest.output.value_object_visitor, type: Ibexa\Rest\Server\Values\RestLocation }
+            - { name: ibexa.rest.output.value_object.visitor, type: Ibexa\Rest\Server\Values\RestLocation }
 
     ezpublish_rest.output.value_object_visitor.Location:
         parent: ezpublish_rest.output.value_object_visitor.base
         class: "%ezpublish_rest.output.value_object_visitor.Location.class%"
         tags:
-            - { name: ezpublish_rest.output.value_object_visitor, type: Ibexa\Contracts\Core\Repository\Values\Content\Location }
+            - { name: ibexa.rest.output.value_object.visitor, type: Ibexa\Contracts\Core\Repository\Values\Content\Location }
         arguments:
             $locationService: '@ezpublish.api.service.location'
             $contentService: '@ezpublish.api.service.content'
@@ -606,20 +606,20 @@ services:
         parent: ezpublish_rest.output.value_object_visitor.base
         class: "%ezpublish_rest.output.value_object_visitor.LocationList.class%"
         tags:
-            - { name: ezpublish_rest.output.value_object_visitor, type: Ibexa\Rest\Server\Values\LocationList }
+            - { name: ibexa.rest.output.value_object.visitor, type: Ibexa\Rest\Server\Values\LocationList }
 
     # Trash
     ezpublish_rest.output.value_object_visitor.Trash:
         parent: ezpublish_rest.output.value_object_visitor.base
         class: "%ezpublish_rest.output.value_object_visitor.Trash.class%"
         tags:
-            - { name: ezpublish_rest.output.value_object_visitor, type: Ibexa\Rest\Server\Values\Trash }
+            - { name: ibexa.rest.output.value_object.visitor, type: Ibexa\Rest\Server\Values\Trash }
 
     ezpublish_rest.output.value_object_visitor.RestTrashItem:
         parent: ezpublish_rest.output.value_object_visitor.base
         class: "%ezpublish_rest.output.value_object_visitor.RestTrashItem.class%"
         tags:
-            - { name: ezpublish_rest.output.value_object_visitor, type: Ibexa\Rest\Server\Values\RestTrashItem }
+            - { name: ibexa.rest.output.value_object.visitor, type: Ibexa\Rest\Server\Values\RestTrashItem }
 
     # Views
     ezpublish_rest.output.value_object_visitor.RestExecutedView:
@@ -627,7 +627,7 @@ services:
         class: "%ezpublish_rest.output.value_object_visitor.RestExecutedView.class%"
         arguments: [ "@ezpublish.api.service.location", "@ezpublish.api.service.content" ]
         tags:
-            - { name: ezpublish_rest.output.value_object_visitor, type: Ibexa\Rest\Server\Values\RestExecutedView }
+            - { name: ibexa.rest.output.value_object.visitor, type: Ibexa\Rest\Server\Values\RestExecutedView }
 
     # Aggregations
 
@@ -635,138 +635,138 @@ services:
         parent: ezpublish_rest.output.value_object_visitor.base
         class: Ibexa\Rest\Server\Output\ValueObjectVisitor\Range
         tags:
-            - { name: ezpublish_rest.output.value_object_visitor, type: Ibexa\Contracts\Core\Repository\Values\Content\Query\Aggregation\Range }
+            - { name: ibexa.rest.output.value_object.visitor, type: Ibexa\Contracts\Core\Repository\Values\Content\Query\Aggregation\Range }
 
     ezpublish_rest.output.value_object_visitor.RangeAggregationResult:
         parent: ezpublish_rest.output.value_object_visitor.base
         class: Ibexa\Rest\Server\Output\ValueObjectVisitor\RangeAggregationResult
         tags:
-            - { name: ezpublish_rest.output.value_object_visitor, type: Ibexa\Contracts\Core\Repository\Values\Content\Search\AggregationResult\RangeAggregationResult }
+            - { name: ibexa.rest.output.value_object.visitor, type: Ibexa\Contracts\Core\Repository\Values\Content\Search\AggregationResult\RangeAggregationResult }
 
     ezpublish_rest.output.value_object_visitor.StatsAggregationResult:
         parent: ezpublish_rest.output.value_object_visitor.base
         class: Ibexa\Rest\Server\Output\ValueObjectVisitor\StatsAggregationResult
         tags:
-            - { name: ezpublish_rest.output.value_object_visitor, type: Ibexa\Contracts\Core\Repository\Values\Content\Search\AggregationResult\StatsAggregationResult }
+            - { name: ibexa.rest.output.value_object.visitor, type: Ibexa\Contracts\Core\Repository\Values\Content\Search\AggregationResult\StatsAggregationResult }
 
     ezpublish_rest.output.value_object_visitor.TermAggregationResult:
         parent: ezpublish_rest.output.value_object_visitor.base
         class: Ibexa\Rest\Server\Output\ValueObjectVisitor\TermAggregationResult
         tags:
-            - { name: ezpublish_rest.output.value_object_visitor, type: Ibexa\Contracts\Core\Repository\Values\Content\Search\AggregationResult\TermAggregationResult }
+            - { name: ibexa.rest.output.value_object.visitor, type: Ibexa\Contracts\Core\Repository\Values\Content\Search\AggregationResult\TermAggregationResult }
 
     # Object state
     ezpublish_rest.output.value_object_visitor.ObjectState:
         parent: ezpublish_rest.output.value_object_visitor.base
         class: Ibexa\Rest\Server\Output\ValueObjectVisitor\ObjectState
         tags:
-            - { name: ezpublish_rest.output.value_object_visitor, type: Ibexa\Contracts\Core\Repository\Values\ObjectState\ObjectState }
+            - { name: ibexa.rest.output.value_object.visitor, type: Ibexa\Contracts\Core\Repository\Values\ObjectState\ObjectState }
 
     ezpublish_rest.output.value_object_visitor.ObjectStateGroup:
         parent: ezpublish_rest.output.value_object_visitor.base
         class: "%ezpublish_rest.output.value_object_visitor.ObjectStateGroup.class%"
         tags:
-            - { name: ezpublish_rest.output.value_object_visitor, type: Ibexa\Contracts\Core\Repository\Values\ObjectState\ObjectStateGroup }
+            - { name: ibexa.rest.output.value_object.visitor, type: Ibexa\Contracts\Core\Repository\Values\ObjectState\ObjectStateGroup }
 
     ezpublish_rest.output.value_object_visitor.CreatedObjectStateGroup:
         parent: ezpublish_rest.output.value_object_visitor.base
         class: "%ezpublish_rest.output.value_object_visitor.CreatedObjectStateGroup.class%"
         tags:
-            - { name: ezpublish_rest.output.value_object_visitor, type: Ibexa\Rest\Server\Values\CreatedObjectStateGroup }
+            - { name: ibexa.rest.output.value_object.visitor, type: Ibexa\Rest\Server\Values\CreatedObjectStateGroup }
 
     ezpublish_rest.output.value_object_visitor.ObjectStateGroupList:
         parent: ezpublish_rest.output.value_object_visitor.base
         class: "%ezpublish_rest.output.value_object_visitor.ObjectStateGroupList.class%"
         tags:
-            - { name: ezpublish_rest.output.value_object_visitor, type: Ibexa\Rest\Server\Values\ObjectStateGroupList }
+            - { name: ibexa.rest.output.value_object.visitor, type: Ibexa\Rest\Server\Values\ObjectStateGroupList }
 
     ezpublish_rest.output.value_object_visitor.RestObjectState:
         parent: ezpublish_rest.output.value_object_visitor.base
         class: "%ezpublish_rest.output.value_object_visitor.RestObjectState.class%"
         tags:
-            - { name: ezpublish_rest.output.value_object_visitor, type: Ibexa\Rest\Values\RestObjectState }
+            - { name: ibexa.rest.output.value_object.visitor, type: Ibexa\Rest\Values\RestObjectState }
 
     ezpublish_rest.output.value_object_visitor.CreatedObjectState:
         parent: ezpublish_rest.output.value_object_visitor.base
         class: "%ezpublish_rest.output.value_object_visitor.CreatedObjectState.class%"
         tags:
-            - { name: ezpublish_rest.output.value_object_visitor, type: Ibexa\Rest\Server\Values\CreatedObjectState }
+            - { name: ibexa.rest.output.value_object.visitor, type: Ibexa\Rest\Server\Values\CreatedObjectState }
 
     ezpublish_rest.output.value_object_visitor.ObjectStateList:
         parent: ezpublish_rest.output.value_object_visitor.base
         class: "%ezpublish_rest.output.value_object_visitor.ObjectStateList.class%"
         tags:
-            - { name: ezpublish_rest.output.value_object_visitor, type: Ibexa\Rest\Server\Values\ObjectStateList }
+            - { name: ibexa.rest.output.value_object.visitor, type: Ibexa\Rest\Server\Values\ObjectStateList }
 
     ezpublish_rest.output.value_object_visitor.ContentObjectStates:
         parent: ezpublish_rest.output.value_object_visitor.base
         class: "%ezpublish_rest.output.value_object_visitor.ContentObjectStates.class%"
         tags:
-            - { name: ezpublish_rest.output.value_object_visitor, type: Ibexa\Rest\Values\ContentObjectStates }
+            - { name: ibexa.rest.output.value_object.visitor, type: Ibexa\Rest\Values\ContentObjectStates }
 
     # Services
     ezpublish_rest.output.value_object_visitor.CountryList:
         parent: ezpublish_rest.output.value_object_visitor.base
         class: "%ezpublish_rest.output.value_object_visitor.CountryList.class%"
         tags:
-            - { name: ezpublish_rest.output.value_object_visitor, type: Ibexa\Rest\Server\Values\CountryList}
+            - { name: ibexa.rest.output.value_object.visitor, type: Ibexa\Rest\Server\Values\CountryList}
 
     # REST specific
     ezpublish_rest.output.value_object_visitor.TemporaryRedirect:
         parent: ezpublish_rest.output.value_object_visitor.base
         class: "%ezpublish_rest.output.value_object_visitor.TemporaryRedirect.class%"
         tags:
-            - { name: ezpublish_rest.output.value_object_visitor, type: Ibexa\Rest\Server\Values\TemporaryRedirect }
+            - { name: ibexa.rest.output.value_object.visitor, type: Ibexa\Rest\Server\Values\TemporaryRedirect }
 
     ezpublish_rest.output.value_object_visitor.PermanentRedirect:
         parent: ezpublish_rest.output.value_object_visitor.base
         class: "%ezpublish_rest.output.value_object_visitor.PermanentRedirect.class%"
         tags:
-            - { name: ezpublish_rest.output.value_object_visitor, type: Ibexa\Rest\Server\Values\PermanentRedirect }
+            - { name: ibexa.rest.output.value_object.visitor, type: Ibexa\Rest\Server\Values\PermanentRedirect }
 
     ezpublish_rest.output.value_object_visitor.ResourceCreated:
         parent: ezpublish_rest.output.value_object_visitor.base
         class: "%ezpublish_rest.output.value_object_visitor.ResourceCreated.class%"
         tags:
-            - { name: ezpublish_rest.output.value_object_visitor, type: Ibexa\Rest\Server\Values\ResourceCreated }
+            - { name: ibexa.rest.output.value_object.visitor, type: Ibexa\Rest\Server\Values\ResourceCreated }
 
     ezpublish_rest.output.value_object_visitor.NoContent:
         parent: ezpublish_rest.output.value_object_visitor.base
         class: "%ezpublish_rest.output.value_object_visitor.NoContent.class%"
         tags:
-            - { name: ezpublish_rest.output.value_object_visitor, type: Ibexa\Rest\Server\Values\NoContent }
+            - { name: ibexa.rest.output.value_object.visitor, type: Ibexa\Rest\Server\Values\NoContent }
 
     ezpublish_rest.output.value_object_visitor.Root:
         parent: ezpublish_rest.output.value_object_visitor.base
         class: "%ezpublish_rest.output.value_object_visitor.Root.class%"
         tags:
-            - { name: ezpublish_rest.output.value_object_visitor, type: Ibexa\Rest\Values\Root }
+            - { name: ibexa.rest.output.value_object.visitor, type: Ibexa\Rest\Values\Root }
 
     ezpublish_rest.output.value_object_visitor.SeeOther:
         parent: ezpublish_rest.output.value_object_visitor.base
         class: "%ezpublish_rest.output.value_object_visitor.SeeOther.class%"
         tags:
-            - { name: ezpublish_rest.output.value_object_visitor, type: Ibexa\Rest\Server\Values\SeeOther }
+            - { name: ibexa.rest.output.value_object.visitor, type: Ibexa\Rest\Server\Values\SeeOther }
 
     ezpublish_rest.output.value_object_visitor.Conflict:
         parent: ezpublish_rest.output.value_object_visitor.base
         class: "%ezpublish_rest.output.value_object_visitor.Conflict.class%"
         arguments: [ true  ]
         tags:
-            - { name: ezpublish_rest.output.value_object_visitor, type: Ibexa\Rest\Server\Values\Conflict }
+            - { name: ibexa.rest.output.value_object.visitor, type: Ibexa\Rest\Server\Values\Conflict }
 
     ezpublish_rest.output.value_object_visitor.Options:
         parent: ezpublish_rest.output.value_object_visitor.base
         class: "%ezpublish_rest.output.value_object_visitor.Options.class%"
         arguments: [ true  ]
         tags:
-            - { name: ezpublish_rest.output.value_object_visitor, type: Ibexa\Rest\Server\Values\Options }
+            - { name: ibexa.rest.output.value_object.visitor, type: Ibexa\Rest\Server\Values\Options }
 
     ezpublish_rest.output.value_object_visitor.OK:
         parent: ezpublish_rest.output.value_object_visitor.base
         class: "%ezpublish_rest.output.value_object_visitor.OK.class%"
         tags:
-            - { name: ezpublish_rest.output.value_object_visitor, type: Ibexa\Rest\Server\Values\OK }
+            - { name: ibexa.rest.output.value_object.visitor, type: Ibexa\Rest\Server\Values\OK }
 
     ezpublish_rest.output.value_object_visitor.cached_value:
         class: "%ezpublish_rest.output.value_object_visitor.cached_value.class%"
@@ -776,10 +776,10 @@ services:
         calls:
             - [setRequestStack, ["@request_stack"]]
         tags:
-            - { name: ezpublish_rest.output.value_object_visitor, type: Ibexa\Rest\Server\Values\CachedValue }
+            - { name: ibexa.rest.output.value_object.visitor, type: Ibexa\Rest\Server\Values\CachedValue }
 
     ezpublish_rest.output.value_object_visitor.BookmarkList:
         parent: ezpublish_rest.output.value_object_visitor.base
         class: Ibexa\Rest\Server\Output\ValueObjectVisitor\BookmarkList
         tags:
-            - { name: ezpublish_rest.output.value_object_visitor, type: Ibexa\Rest\Server\Values\BookmarkList }
+            - { name: ibexa.rest.output.value_object.visitor, type: Ibexa\Rest\Server\Values\BookmarkList }

--- a/tests/bundle/DependencyInjection/Compiler/FieldTypeProcessorPassTest.php
+++ b/tests/bundle/DependencyInjection/Compiler/FieldTypeProcessorPassTest.php
@@ -43,7 +43,6 @@ class FieldTypeProcessorPassTest extends TestCase
     public function dataProviderForProcess(): iterable
     {
         yield ['ibexa.rest.field_type.processor'];
-        yield ['ezpublish_rest.field_type_processor'];
     }
 }
 

--- a/tests/bundle/DependencyInjection/Compiler/InputHandlerPassTest.php
+++ b/tests/bundle/DependencyInjection/Compiler/InputHandlerPassTest.php
@@ -17,7 +17,7 @@ class InputHandlerPassTest extends TestCase
     public function testProcess()
     {
         $visitorDefinition = new Definition();
-        $visitorDefinition->addTag('ezpublish_rest.input.handler', ['format' => 'test']);
+        $visitorDefinition->addTag('ibexa.rest.input.handler', ['format' => 'test']);
 
         $containerBuilder = new ContainerBuilder();
         $containerBuilder->addDefinitions(

--- a/tests/bundle/DependencyInjection/Compiler/InputParserPassTest.php
+++ b/tests/bundle/DependencyInjection/Compiler/InputParserPassTest.php
@@ -17,7 +17,10 @@ class InputParserPassTest extends TestCase
     public function testProcess()
     {
         $visitorDefinition = new Definition();
-        $visitorDefinition->addTag('ezpublish_rest.input.parser', ['mediaType' => 'application/vnd.ez.api.UnitTest']);
+        $visitorDefinition->addTag(
+            'ibexa.rest.input.parser',
+            ['mediaType' => 'application/vnd.ez.api.UnitTest']
+        );
 
         $containerBuilder = new ContainerBuilder();
         $containerBuilder->addDefinitions(

--- a/tests/bundle/DependencyInjection/Compiler/OutputVisitorPassTest.php
+++ b/tests/bundle/DependencyInjection/Compiler/OutputVisitorPassTest.php
@@ -14,12 +14,6 @@ use Symfony\Component\DependencyInjection\Reference;
 
 class OutputVisitorPassTest extends AbstractCompilerPassTestCase
 {
-    /**
-     * Register the compiler pass under test, just like you would do inside a bundle's load()
-     * method:.
-     *
-     *   $container->addCompilerPass(new MyCompilerPass());
-     */
     protected function registerCompilerPass(ContainerBuilder $container): void
     {
         $container->addCompilerPass(new OutputVisitorPass());
@@ -29,13 +23,16 @@ class OutputVisitorPassTest extends AbstractCompilerPassTestCase
     {
         $stringRegexp = '(^.*/.*$)';
         $stringDefinition = new Definition();
-        $stringDefinition->addTag('ezpublish_rest.output.visitor', ['regexps' => 'ezpublish_rest.output.visitor.test.regexps']);
+        $stringDefinition->addTag(
+            'ibexa.rest.output.visitor',
+            ['regexps' => 'ezpublish_rest.output.visitor.test.regexps']
+        );
         $this->setParameter('ezpublish_rest.output.visitor.test.regexps', [$stringRegexp]);
         $this->setDefinition('ezpublish_rest.output.visitor.test_string', $stringDefinition);
 
         $arrayRegexp = '(^application/json$)';
         $arrayDefinition = new Definition();
-        $arrayDefinition->addTag('ezpublish_rest.output.visitor', ['regexps' => [$arrayRegexp]]);
+        $arrayDefinition->addTag('ibexa.rest.output.visitor', ['regexps' => [$arrayRegexp]]);
         $this->setDefinition('ezpublish_rest.output.visitor.test_array', $arrayDefinition);
 
         $this->setDefinition('ezpublish_rest.output.visitor.dispatcher', new Definition());
@@ -89,7 +86,7 @@ class OutputVisitorPassTest extends AbstractCompilerPassTestCase
 
         foreach ($definitions as $name => $data) {
             $definition = new Definition();
-            $definition->addTag('ezpublish_rest.output.visitor', $data);
+            $definition->addTag('ibexa.rest.output.visitor', $data);
             $this->setDefinition('ezpublish_rest.output.visitor.test_' . $name, $definition);
         }
 

--- a/tests/bundle/DependencyInjection/Compiler/ValueObjectVisitorPassTest.php
+++ b/tests/bundle/DependencyInjection/Compiler/ValueObjectVisitorPassTest.php
@@ -17,7 +17,7 @@ class ValueObjectVisitorPassTest extends TestCase
     public function testProcess()
     {
         $visitorDefinition = new Definition();
-        $visitorDefinition->addTag('ezpublish_rest.output.value_object_visitor', ['type' => 'test']);
+        $visitorDefinition->addTag('ibexa.rest.output.value_object.visitor', ['type' => 'test']);
 
         $containerBuilder = new ContainerBuilder();
         $containerBuilder->addDefinitions(


### PR DESCRIPTION
| Question                                  | Answer
| ---------------------------------------- | ------------------
| **JIRA issue**                          | [IBX-1694](https://issues.ibexa.co/browse/IBX-1694)
| **Type**                                   | feature
| **Target Ibexa version** | `v4.0`
| **BC breaks**                          | yes, requires ibexa/compatibility-layer#12

In this Pull Request we rename Ibexa's dependency injection container service tags according to the map provided by ibexa/compatibility-layer#12 as a part of the rebranding process. Backward compatibility for old service tags is provided by ibexa/compatibility-layer#12.

#### Checklist:
- [x] Provided PR description.
- [x] Tested the solution manually.
- [ ] Provided automated test coverage.
- [x] Asked for a review
