### PR TITLE
IBX-1696: Rebranded Container parameters and Config Resolver namespaces

### DIFF
--- a/src/bundle/DependencyInjection/IbexaRestExtension.php
+++ b/src/bundle/DependencyInjection/IbexaRestExtension.php
@@ -44,7 +44,7 @@ class IbexaRestExtension extends Extension implements PrependExtensionInterface
         $loader->load('security.yml');
         $loader->load('default_settings.yml');
 
-        $processor = new ConfigurationProcessor($container, 'ezsettings');
+        $processor = new ConfigurationProcessor($container, 'ibexa.site_access.config');
         $processor->mapConfigArray('rest_root_resources', $config);
     }
 

--- a/src/bundle/Resources/config/default_settings.yml
+++ b/src/bundle/Resources/config/default_settings.yml
@@ -1,11 +1,11 @@
 parameters:
     # Intention string used by the CSRF protection in REST context.
-    ezpublish_rest.csrf_token_intention: rest
+    ibexa.rest.csrf_token_intention: rest
 
     # URI part that all REST routes begin with. By this a REST request is recognized.
-    ezpublish_rest.path_prefix: /api/ibexa/v2
+    ibexa.rest.path_prefix: /api/ibexa/v2
 
-    ezsettings.default.rest_root_resources:
+    ibexa.site_access.config.default.rest_root_resources:
         content:
             mediaType: ''
             href: 'router.generate("ibexa.rest.create_content")'

--- a/src/bundle/Resources/config/services.yml
+++ b/src/bundle/Resources/config/services.yml
@@ -1,8 +1,8 @@
 parameters:
-    ezpublish_rest.output.visitor.json.regexps:
+    ibexa.rest.output.visitor.json.regexps:
         - '(^application/vnd\.ibexa\.api\.[A-Za-z]+\+json$)'
         - '(^application/json$)'
-    ezpublish_rest.output.visitor.xml.regexps:
+    ibexa.rest.output.visitor.xml.regexps:
         - '(^application/vnd\.ibexa\.api\.[A-Za-z]+\+xml$)'
         - '(^application/xml$)'
         - '(^.*/.*$)'
@@ -155,7 +155,7 @@ services:
         class: Ibexa\Rest\Server\Controller\SessionController
         parent: Ibexa\Rest\Server\Controller
         arguments:
-            - "%ezpublish_rest.csrf_token_intention%"
+            - '%ibexa.rest.csrf_token_intention%'
             - '@Ibexa\Contracts\Core\Repository\PermissionResolver'
             - '@ibexa.api.service.user'
             - '@?ibexa.rest.session_authenticator'
@@ -191,7 +191,7 @@ services:
         arguments:
             - "@event_dispatcher"
             - "%form.type_extension.csrf.enabled%"
-            - "%ezpublish_rest.csrf_token_intention%"
+            - '%ibexa.rest.csrf_token_intention%'
             - '@?Ibexa\Rest\Server\Security\CsrfTokenManager'
         tags:
             - { name: kernel.event_subscriber }
@@ -201,7 +201,7 @@ services:
         tags: [controller.service_arguments]
 
     Ibexa\Rest\Server\Controller\Services:
-        arguments: ["%ezpublish.fieldType.ezcountry.data%"]
+        arguments: ['%ibexa.field_type.country.data%']
         tags: [controller.service_arguments]
 
     Ibexa\Rest\FieldTypeProcessorRegistry:
@@ -284,7 +284,7 @@ services:
             - '@Ibexa\Rest\Output\Generator\Json'
             - '@Ibexa\Contracts\Rest\Output\ValueObjectVisitorDispatcher'
         tags:
-            - { name: ibexa.rest.output.visitor, regexps: ezpublish_rest.output.visitor.json.regexps }
+            - { name: ibexa.rest.output.visitor, regexps: ibexa.rest.output.visitor.json.regexps }
 
     ibexa.rest.output.visitor.xml:
         class: Ibexa\Contracts\Rest\Output\Visitor
@@ -292,7 +292,7 @@ services:
             - '@Ibexa\Rest\Output\Generator\Xml'
             - '@Ibexa\Contracts\Rest\Output\ValueObjectVisitorDispatcher'
         tags:
-            - { name: ibexa.rest.output.visitor, regexps: ezpublish_rest.output.visitor.xml.regexps }
+            - { name: ibexa.rest.output.visitor, regexps: ibexa.rest.output.visitor.xml.regexps }
 
     # format output generators
     Ibexa\Rest\Output\Generator\Xml:


### PR DESCRIPTION
| Question                                  | Answer
| ---------------------------------------- | ------------------
| **JIRA issue**                          | [IBX-1696](https://issues.ibexa.co/browse/IBX-1696)
| **Type**                                   | feature
| **Target Ibexa version** | `v4.0`
| **BC breaks**                          | yes, requires ibexa/compatibility-layer#31

Rebranded service container parameter names and Ibexa Config Resolver namespaces to follow unified pattern

### TODO

- [ ] Run regressions
- [ ] Test manually
