### PR TITLE
IBX-2702: Allowed parsing objects which are not ValueObject based

### DIFF
--- a/src/contracts/Input/Parser.php
+++ b/src/contracts/Input/Parser.php
@@ -17,7 +17,7 @@ abstract class Parser
      * @param array $data
      * @param \Ibexa\Contracts\Rest\Input\ParsingDispatcher $parsingDispatcher
      *
-     * @return \Ibexa\Contracts\Core\Repository\Values\ValueObject
+     * @return \Ibexa\Contracts\Core\Repository\Values\ValueObject|object
      */
     abstract public function parse(array $data, ParsingDispatcher $parsingDispatcher);
 }


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [IBX-2702](https://issues.ibexa.co/browse/IBX-2702)
| **Type**| bug/feature/improvement
| **Target version** | e.g.: Ibexa `v4.1`
| **BC breaks**      | no
| **Tests pass**     | yes
| **Doc needed**     | no

<!-- Replace this comment with Pull Request description -->

**TODO**:
- [ ] Implement tests.
- [ ] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [ ] Ask for Code Review.
