### PR TITLE
IBX-3757: Added `dataKey` getter allowing to identify REST Sort Clauses

### DIFF
--- a/src/lib/Server/Input/Parser/SortClause/DataKeyValueObjectClass.php
+++ b/src/lib/Server/Input/Parser/SortClause/DataKeyValueObjectClass.php
@@ -67,6 +67,11 @@ class DataKeyValueObjectClass extends BaseParser
 
         return new $this->valueObjectClass($direction);
     }
+
+    public function getDataKey(): string
+    {
+        return $this->dataKey;
+    }
 }
 
 class_alias(DataKeyValueObjectClass::class, 'EzSystems\EzPlatformRest\Server\Input\Parser\SortClause\DataKeyValueObjectClass');


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [IBX-3757](https://issues.ibexa.co/browse/IBX-3757)
| **Type**| improvement
| **Target version** | `4.3`
| **BC breaks**      | no
| **Tests pass**     | yes
| **Doc needed**     | no

Currently, there is no easy way to list Sort Clauses available for REST usage. Such need presented itself in Product Catalog as we want to inform the API consumer which Sort Clauses are available for product querying.

Ref: https://github.com/ibexa/product-catalog/pull/813/files#diff-9e5940343af2755db2be533fdc4dac336bd9810987adf7d99e3ef973676220baR174

**TODO**:
- [ ] Implement tests.
- [x] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [x] Ask for Code Review.
