### PR TITLE
IBX-4043: Added API current user / session routes

### DIFF
--- a/src/bundle/Resources/config/routing.yml
+++ b/src/bundle/Resources/config/routing.yml
@@ -1126,6 +1126,13 @@ ibexa.rest.create_session:
         csrf_protection: false
     methods: [POST]
 
+ibexa.rest.check_session:
+    path: /user/sessions/current
+    controller: Ibexa\Rest\Server\Controller\SessionController::checkSessionAction
+    methods: [GET]
+    defaults:
+        csrf_protection: false
+
 ibexa.rest.delete_session:
     path: /user/sessions/{sessionId}
     defaults:
@@ -1140,12 +1147,6 @@ ibexa.rest.refresh_session:
         csrf_protection: false
     methods: [POST]
 
-ibexa.rest.check_session:
-    path: /user/sessions
-    controller: Ibexa\Rest\Server\Controller\SessionController::checkSessionAction
-    methods: [GET]
-    defaults:
-        csrf_protection: false
 
 # URL aliases
 

--- a/src/bundle/Resources/config/routing.yml
+++ b/src/bundle/Resources/config/routing.yml
@@ -1142,7 +1142,7 @@ ibexa.rest.refresh_session:
 
 ibexa.rest.check_session:
     path: /user/sessions
-    controller: Ibexa\Rest\Server\Controller\SessionController:checkSessionAction
+    controller: Ibexa\Rest\Server\Controller\SessionController::checkSessionAction
     methods: [GET]
     defaults:
         csrf_protection: false

--- a/src/bundle/Resources/config/routing.yml
+++ b/src/bundle/Resources/config/routing.yml
@@ -915,6 +915,11 @@ ibexa.rest.load_user:
     requirements:
         userId: \d+
 
+ibexa.rest.current_user:
+    path: /user/current
+    controller: Ibexa\Rest\Server\Controller\User::redirectToCurrentUser
+    methods: [GET]
+
 ibexa.rest.update_user:
     path: /user/users/{userId}
     defaults:
@@ -1135,6 +1140,12 @@ ibexa.rest.refresh_session:
         csrf_protection: false
     methods: [POST]
 
+ibexa.rest.check_session:
+    path: /user/sessions
+    controller: Ibexa\Rest\Server\Controller\SessionController:checkSessionAction
+    methods: [GET]
+    defaults:
+        csrf_protection: false
 
 # URL aliases
 

--- a/src/lib/Server/Controller/SessionController.php
+++ b/src/lib/Server/Controller/SessionController.php
@@ -139,6 +139,33 @@ class SessionController extends Controller
     }
 
     /**
+     * @return \Ibexa\Rest\Server\Values\UserSession|\Symfony\Component\HttpFoundation\Response
+     */
+    public function checkSessionAction(Request $request)
+    {
+        $session = $request->getSession();
+
+        if ($session === null || !$session->isStarted()) {
+            $response = $this->getAuthenticator()->logout($request);
+            $response->setStatusCode(404);
+
+            return $response;
+        }
+
+        $currentUser = $this->userService->loadUser(
+            $this->permissionResolver->getCurrentUserReference()->getUserId()
+        );
+
+        return new Values\UserSession(
+            $currentUser,
+            $session->getName(),
+            $session->getId(),
+            $request->headers->get('X-CSRF-Token'),
+            false
+        );
+    }
+
+    /**
      * Deletes given session.
      *
      * @param string $sessionId

--- a/src/lib/Server/Controller/User.php
+++ b/src/lib/Server/Controller/User.php
@@ -27,6 +27,8 @@ use Ibexa\Rest\Server\Exceptions;
 use Ibexa\Rest\Server\Exceptions\ForbiddenException;
 use Ibexa\Rest\Server\Values;
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Exception\UnauthorizedHttpException;
+use Symfony\Component\Security\Core\User\UserInterface;
 use Symfony\Component\Security\Csrf\TokenStorage\TokenStorageInterface;
 
 /**
@@ -212,6 +214,22 @@ class User extends RestController
                 $relations
             ),
             ['locationId' => $userContentInfo->mainLocationId]
+        );
+    }
+
+    /**
+     * @see \Symfony\Component\Security\Http\Controller\UserValueResolver
+     */
+    public function redirectToCurrentUser(?UserInterface $user): Values\TemporaryRedirect
+    {
+        if ($user === null) {
+            throw new UnauthorizedHttpException('', 'Not logged in.');
+        }
+
+        $userReference = $this->permissionResolver->getCurrentUserReference();
+
+        return new Values\TemporaryRedirect(
+            $this->router->generate('ibexa.rest.load_user', ['userId' => $userReference->getUserId()])
         );
     }
 

--- a/src/lib/Server/Values/UserSession.php
+++ b/src/lib/Server/Values/UserSession.php
@@ -49,6 +49,8 @@ class UserSession extends RestValue
      */
     public $exists;
 
+    public bool $created;
+
     /**
      * @param \Ibexa\Contracts\Core\Repository\Values\User\User $user
      * @param string $sessionName

--- a/tests/bundle/Functional/HttpOptionsTest.php
+++ b/tests/bundle/Functional/HttpOptionsTest.php
@@ -34,7 +34,7 @@ class HttpOptionsTest extends TestCase
 
         self::assertHttpResponseHasHeader($response, 'Allow');
         $actualMethods = explode(',', $response->getHeader('Allow')[0]);
-        self::assertEquals($expectedMethods, $actualMethods);
+        self::assertEqualsCanonicalizing($expectedMethods, $actualMethods);
     }
 
     /**

--- a/tests/bundle/Functional/HttpOptionsTest.php
+++ b/tests/bundle/Functional/HttpOptionsTest.php
@@ -42,7 +42,7 @@ class HttpOptionsTest extends TestCase
      *
      * @see testHttpOptions
      *
-     * @return array Data Provider sets
+     * @return array<array{non-empty-string, array<non-empty-string>}> Data Provider sets
      */
     public function providerForTestHttpOptions(): array
     {
@@ -96,6 +96,7 @@ class HttpOptionsTest extends TestCase
             ['/user/roles/1/draft', ['GET', 'PATCH', 'PUBLISH', 'DELETE']],
             ['/user/roles/1/policies', ['GET', 'POST', 'DELETE']],
             ['/user/roles/1/policies/328', ['GET', 'PATCH', 'DELETE']],
+            ['/user/current', ['GET']],
             ['/user/users', ['HEAD', 'GET']],
             ['/user/users/10', ['GET', 'PATCH', 'DELETE']],
             ['/user/users/10/groups', ['GET', 'POST']],
@@ -111,7 +112,7 @@ class HttpOptionsTest extends TestCase
             ['/user/groups/4/users', ['GET', 'POST']],
             ['/user/groups/4/roles', ['GET', 'POST']],
             ['/user/groups/13/roles/1', ['GET', 'DELETE']],
-            ['/user/sessions', ['POST']],
+            ['/user/sessions', ['GET', 'POST']],
             ['/user/sessions/sess_123', ['DELETE']],
             ['/user/sessions/sess_123/refresh', ['POST']],
             ['/content/urlaliases', ['GET', 'POST']],

--- a/tests/bundle/Functional/HttpOptionsTest.php
+++ b/tests/bundle/Functional/HttpOptionsTest.php
@@ -112,7 +112,7 @@ class HttpOptionsTest extends TestCase
             ['/user/groups/4/users', ['GET', 'POST']],
             ['/user/groups/4/roles', ['GET', 'POST']],
             ['/user/groups/13/roles/1', ['GET', 'DELETE']],
-            ['/user/sessions', ['GET', 'POST']],
+            ['/user/sessions', ['POST']],
             ['/user/sessions/sess_123', ['DELETE']],
             ['/user/sessions/sess_123/refresh', ['POST']],
             ['/content/urlaliases', ['GET', 'POST']],

--- a/tests/bundle/Functional/SessionTest.php
+++ b/tests/bundle/Functional/SessionTest.php
@@ -153,7 +153,7 @@ class SessionTest extends TestCase
         $session = $this->login();
         $request = $this->createHttpRequest(
             'GET',
-            '/api/ibexa/v2/user/sessions',
+            '/api/ibexa/v2/user/sessions/current',
             '',
             'Session+json',
             '',
@@ -176,7 +176,7 @@ class SessionTest extends TestCase
     {
         $request = $this->createHttpRequest(
             'GET',
-            '/api/ibexa/v2/user/sessions',
+            '/api/ibexa/v2/user/sessions/current',
             '',
             'Session+json'
         );

--- a/tests/bundle/Functional/SessionTest.php
+++ b/tests/bundle/Functional/SessionTest.php
@@ -146,6 +146,47 @@ class SessionTest extends TestCase
     }
 
     /**
+     * @depends testCreateSession
+     */
+    public function testCheckSession(): void
+    {
+        $session = $this->login();
+        $request = $this->createHttpRequest(
+            'GET',
+            '/api/ibexa/v2/user/sessions',
+            '',
+            'Session+json',
+            '',
+            [
+                'Cookie' => sprintf('%s=%s', $session->name, $session->identifier),
+                'X-CSRF-Token' => $session->csrfToken,
+            ]
+        );
+        $response = $this->sendHttpRequest($request);
+        self::assertHttpResponseCodeEquals($response, 200);
+        $contents = $response->getBody()->getContents();
+        $data = json_decode($contents, true, JSON_THROW_ON_ERROR);
+        self::assertArrayHasKey('Session', $data);
+    }
+
+    /**
+     * @depends testCreateSession
+     */
+    public function testCheckSessionWithoutOne(): void
+    {
+        $request = $this->createHttpRequest(
+            'GET',
+            '/api/ibexa/v2/user/sessions',
+            '',
+            'Session+json'
+        );
+        $response = $this->sendHttpRequest($request);
+        self::assertHttpResponseCodeEquals($response, 404);
+        $contents = $response->getBody()->getContents();
+        self::assertEmpty($contents);
+    }
+
+    /**
      * @param \stdClass $session
      *
      * @return \Psr\Http\Message\RequestInterface

--- a/tests/bundle/Functional/TestCase.php
+++ b/tests/bundle/Functional/TestCase.php
@@ -394,13 +394,13 @@ XML;
      *
      * @return \stdClass an object with the name, identifier, csrftoken properties
      */
-    protected function login()
+    protected function login(): \stdClass
     {
         $request = $this->createAuthenticationHttpRequest($this->getLoginUsername(), $this->getLoginPassword());
         $response = $this->sendHttpRequest($request);
         self::assertHttpResponseCodeEquals($response, 201);
 
-        return json_decode($response->getBody())->Session;
+        return json_decode($response->getBody()->getContents(), false, JSON_THROW_ON_ERROR)->Session;
     }
 
     /**

--- a/tests/bundle/Functional/UserTest.php
+++ b/tests/bundle/Functional/UserTest.php
@@ -174,6 +174,30 @@ XML;
         self::assertHttpResponseCodeEquals($response, 200);
     }
 
+    public function testRedirectToCurrentUser(): void
+    {
+        $request = $this->createHttpRequest('GET', '/api/ibexa/v2/user/current');
+
+        $response = $this->sendHttpRequest($request);
+
+        self::assertHttpResponseCodeEquals($response, 307);
+        self::assertTrue($response->hasHeader('Location'));
+        [ $location ] = $response->getHeader('Location');
+        self::assertSame('/api/ibexa/v2/user/users/14', $location);
+    }
+
+    public function testRedirectToCurrentUserWhenNotLoggedIn(): void
+    {
+        $request = $this
+            ->createHttpRequest('GET', '/api/ibexa/v2/user/current')
+            ->withoutHeader('Cookie');
+
+        $response = $this->sendHttpRequest($request);
+
+        self::assertHttpResponseCodeEquals($response, 401);
+        self::assertFalse($response->hasHeader('Location'));
+    }
+
     /**
      * @depends testCreateUser
      * Covers PATCH /user/users/{userId}

--- a/tests/bundle/Functional/UserTest.php
+++ b/tests/bundle/Functional/UserTest.php
@@ -10,6 +10,8 @@ use Ibexa\Tests\Bundle\Rest\Functional\TestCase as RESTFunctionalTestCase;
 
 class UserTest extends RESTFunctionalTestCase
 {
+    private const HEADER_LOCATION = 'Location';
+
     /**
      * Covers GET /user/groups/root.
      */
@@ -59,9 +61,9 @@ XML;
         $response = $this->sendHttpRequest($request);
 
         self::assertHttpResponseCodeEquals($response, 201);
-        self::assertHttpResponseHasHeader($response, 'Location');
+        self::assertHttpResponseHasHeader($response, self::HEADER_LOCATION);
 
-        $href = $response->getHeader('Location')[0];
+        $href = $response->getHeader(self::HEADER_LOCATION)[0];
         $this->addCreatedElement($href);
 
         return $href;
@@ -153,9 +155,9 @@ XML;
         $response = $this->sendHttpRequest($request);
 
         self::assertHttpResponseCodeEquals($response, 201);
-        self::assertHttpResponseHasHeader($response, 'Location');
+        self::assertHttpResponseHasHeader($response, self::HEADER_LOCATION);
 
-        $href = $response->getHeader('Location')[0];
+        $href = $response->getHeader(self::HEADER_LOCATION)[0];
         $this->addCreatedElement($href);
 
         return $href;
@@ -181,9 +183,7 @@ XML;
         $response = $this->sendHttpRequest($request);
 
         self::assertHttpResponseCodeEquals($response, 307);
-        self::assertTrue($response->hasHeader('Location'));
-        [ $location ] = $response->getHeader('Location');
-        self::assertSame('/api/ibexa/v2/user/users/14', $location);
+        self::assertHttpResponseHasHeader($response, self::HEADER_LOCATION, '/api/ibexa/v2/user/users/14');
     }
 
     public function testRedirectToCurrentUserWhenNotLoggedIn(): void
@@ -195,7 +195,7 @@ XML;
         $response = $this->sendHttpRequest($request);
 
         self::assertHttpResponseCodeEquals($response, 401);
-        self::assertFalse($response->hasHeader('Location'));
+        self::assertFalse($response->hasHeader(self::HEADER_LOCATION));
     }
 
     /**
@@ -418,9 +418,9 @@ XML;
         $response = $this->sendHttpRequest($request);
 
         self::assertHttpResponseCodeEquals($response, 201);
-        self::assertHttpResponseHasHeader($response, 'Location');
+        self::assertHttpResponseHasHeader($response, self::HEADER_LOCATION);
 
-        $href = $response->getHeader('Location')[0];
+        $href = $response->getHeader(self::HEADER_LOCATION)[0];
         $this->addCreatedElement($href);
 
         return $href;


### PR DESCRIPTION
| Question                                  | Answer |
| ---------------------------------------- | ------------------ |
| **JIRA issue**                          | [IBX-4043](https://issues.ibexa.co/browse/IBX-4043) |
| **Type**                                   | feature |
| **Target Ibexa version** | `v4.3` |
| **BC breaks**                          | no |

This PR adds new routes to REST API related to Ibexa Connect authentication needs.
 * `[GET] /user/current` - redirects to current user load API.
 * `[GET] /user/sessions/current` - return current User Session object.

They are necessary to explicitly confirm that user is logged in, without invoking any other route. 

Other routes may return information for anonymous users as well, so they are ill suited for this task (and it would be a workaround at best).

## Doc needed

REST API documentation will need to receive new endpoints' description.

#### Checklist:
- [x] Provided PR description.
- [x] Tested the solution manually.
- [x] Provided automated test coverage.
- [x] Checked that target branch is set correctly (main for features, the oldest supported for bugs).
- [x] Ran PHP CS Fixer for new PHP code (use `$ composer fix-cs`).
- [x] Asked for a review (ping for example `@ibexa/php-dev` for back-end changes and/or `@ibexa/javascript-dev` for front-end changes).
