### PR TITLE
IBX-4359: Added dedicated service for token-based authentication

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,10 +17,10 @@
     },
     "autoload-dev": {
         "psr-4": {
-            "EzSystems\\EzPlatformRestBundle\\Tests\\": "tests/bundle/",
-            "EzSystems\\EzPlatformRest\\Tests\\": "tests/lib/",
             "Ibexa\\Tests\\Rest\\": "tests/lib/",
-            "Ibexa\\Tests\\Bundle\\Rest\\": "tests/bundle/"
+            "Ibexa\\Tests\\Bundle\\Rest\\": "tests/bundle/",
+            "Ibexa\\Tests\\Contracts\\Rest\\": "tests/contracts/",
+            "Ibexa\\Tests\\Integration\\Rest\\": "tests/integration/"
         }
     },
     "require": {

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -13,11 +13,9 @@
       <directory>tests/bundle/</directory>
       <exclude>tests/bundle/Functional</exclude>
     </testsuite>
-    <testsuite name="Ibexa REST Contracts">
-      <directory>tests/contracts/</directory>
-    </testsuite>
     <testsuite name="Ibexa REST">
       <directory>tests/lib/</directory>
+      <directory>tests/contracts/</directory>
       <exclude>tests/lib/Server</exclude>
     </testsuite>
     <testsuite name="Ibexa REST Server Tests">

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -13,6 +13,9 @@
       <directory>tests/bundle/</directory>
       <exclude>tests/bundle/Functional</exclude>
     </testsuite>
+    <testsuite name="Ibexa REST Contracts">
+      <directory>tests/contracts/</directory>
+    </testsuite>
     <testsuite name="Ibexa REST">
       <directory>tests/lib/</directory>
       <exclude>tests/lib/Server</exclude>

--- a/src/bundle/Resources/config/security.yml
+++ b/src/bundle/Resources/config/security.yml
@@ -1,5 +1,22 @@
 parameters:
 services:
+    ibexa.rest.security.expression_language:
+        class: Symfony\Component\ExpressionLanguage\ExpressionLanguage
+        arguments:
+            $cache: '@cache.system'
+
+    ibexa.rest.security.request_matcher.bearer_authentication:
+        class: Symfony\Component\HttpFoundation\ExpressionRequestMatcher
+        calls:
+            - [
+                setExpression,
+                [
+                    '@ibexa.rest.security.expression_language',
+                    'attributes["is_rest_request"] === true 
+                        && (attributes["_route"] === "ibexa.rest.create_token" or request.headers.has("Authorization"))'
+                ]
+            ]
+
     # Following service will be aliased at compile time to "ezpublish_rest.session_authenticator" by the Security factory.
     ibexa.rest.security.authentication.listener.session:
         class: Ibexa\Rest\Server\Security\RestAuthenticator

--- a/src/bundle/Resources/config/security.yml
+++ b/src/bundle/Resources/config/security.yml
@@ -1,22 +1,5 @@
 parameters:
 services:
-    ibexa.rest.security.expression_language:
-        class: Symfony\Component\ExpressionLanguage\ExpressionLanguage
-        arguments:
-            $cache: '@cache.system'
-
-    ibexa.rest.security.request_matcher.bearer_authentication:
-        class: Symfony\Component\HttpFoundation\ExpressionRequestMatcher
-        calls:
-            - [
-                setExpression,
-                [
-                    '@ibexa.rest.security.expression_language',
-                    'attributes["is_rest_request"] === true 
-                        && (attributes["_route"] === "ibexa.rest.create_token" or request.headers.has("Authorization"))'
-                ]
-            ]
-
     # Following service will be aliased at compile time to "ezpublish_rest.session_authenticator" by the Security factory.
     ibexa.rest.security.authentication.listener.session:
         class: Ibexa\Rest\Server\Security\RestAuthenticator
@@ -28,6 +11,8 @@ services:
             - '@ibexa.config.resolver'
             - "@?logger"
         abstract: true
+
+    Ibexa\Contracts\Rest\Security\AuthorizationHeaderRESTRequestMatcher: ~
 
     Ibexa\Rest\Server\Security\RestLogoutHandler:
         arguments:

--- a/src/contracts/Security/AuthorizationHeaderRESTRequestMatcher.php
+++ b/src/contracts/Security/AuthorizationHeaderRESTRequestMatcher.php
@@ -21,7 +21,7 @@ final class AuthorizationHeaderRESTRequestMatcher extends RequestMatcher
 
         if (
             $request->attributes->get('_route') === 'ibexa.rest.create_token'
-            || $request->headers->has('Authorization')
+            || empty($request->headers->get('Authorization'))
         ) {
             return parent::matches($request);
         }

--- a/src/contracts/Security/AuthorizationHeaderRESTRequestMatcher.php
+++ b/src/contracts/Security/AuthorizationHeaderRESTRequestMatcher.php
@@ -19,11 +19,11 @@ final class AuthorizationHeaderRESTRequestMatcher extends RequestMatcher
             return false;
         }
 
-        if ($request->attributes->get('_route') !== 'ibexa.rest.create_token'
-            && !$request->headers->has('Authorization')) {
-            return false;
+        if ($request->attributes->get('_route') === 'ibexa.rest.create_token'
+            || $request->headers->has('Authorization')) {
+            return parent::matches($request);
         }
 
-        return parent::matches($request);
+        return false;
     }
 }

--- a/src/contracts/Security/AuthorizationHeaderRESTRequestMatcher.php
+++ b/src/contracts/Security/AuthorizationHeaderRESTRequestMatcher.php
@@ -19,8 +19,10 @@ final class AuthorizationHeaderRESTRequestMatcher extends RequestMatcher
             return false;
         }
 
-        if ($request->attributes->get('_route') === 'ibexa.rest.create_token'
-            || $request->headers->has('Authorization')) {
+        if (
+            $request->attributes->get('_route') === 'ibexa.rest.create_token'
+            || $request->headers->has('Authorization')
+        ) {
             return parent::matches($request);
         }
 

--- a/src/contracts/Security/AuthorizationHeaderRESTRequestMatcher.php
+++ b/src/contracts/Security/AuthorizationHeaderRESTRequestMatcher.php
@@ -1,0 +1,29 @@
+<?php
+
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace Ibexa\Contracts\Rest\Security;
+
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\RequestMatcher;
+
+final class AuthorizationHeaderRESTRequestMatcher extends RequestMatcher
+{
+    public function matches(Request $request): bool
+    {
+        if ($request->attributes->get('is_rest_request', false) !== true) {
+            return false;
+        }
+
+        if ($request->attributes->get('_route') !== 'ibexa.rest.create_token'
+            && !$request->headers->has('Authorization')) {
+            return false;
+        }
+
+        return parent::matches($request);
+    }
+}

--- a/src/contracts/Security/AuthorizationHeaderRESTRequestMatcher.php
+++ b/src/contracts/Security/AuthorizationHeaderRESTRequestMatcher.php
@@ -21,7 +21,7 @@ final class AuthorizationHeaderRESTRequestMatcher extends RequestMatcher
 
         if (
             $request->attributes->get('_route') === 'ibexa.rest.create_token'
-            || empty($request->headers->get('Authorization'))
+            || !empty($request->headers->get('Authorization'))
         ) {
             return parent::matches($request);
         }

--- a/tests/contracts/Security/AuthorizationHeaderRESTRequestMatcherTest.php
+++ b/tests/contracts/Security/AuthorizationHeaderRESTRequestMatcherTest.php
@@ -44,4 +44,16 @@ final class AuthorizationHeaderRESTRequestMatcherTest extends TestCase
 
         self::assertTrue($matcher->matches($request));
     }
+
+    public function testMatchesRestJwtCreationEndpoint(): void
+    {
+        $matcher = new AuthorizationHeaderRESTRequestMatcher();
+
+        $request = new Request([], [], [
+            'is_rest_request' => true,
+            '_route' => 'ibexa.rest.create_token',
+        ]);
+
+        self::assertTrue($matcher->matches($request));
+    }
 }

--- a/tests/contracts/Security/AuthorizationHeaderRESTRequestMatcherTest.php
+++ b/tests/contracts/Security/AuthorizationHeaderRESTRequestMatcherTest.php
@@ -1,0 +1,46 @@
+<?php
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace Ibexa\Tests\Contracts\Rest\Security;
+
+use Ibexa\Contracts\Rest\Security\AuthorizationHeaderRESTRequestMatcher;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpFoundation\Request;
+
+final class AuthorizationHeaderRESTRequestMatcherTest extends TestCase
+{
+    public function testDoesNotMatchNonRestRequests(): void
+    {
+        $matcher = new AuthorizationHeaderRESTRequestMatcher();
+
+        self::assertFalse($matcher->matches(new Request()));
+    }
+
+    public function testDoesNotMatchRestRequestsWithoutHeader(): void
+    {
+        $matcher = new AuthorizationHeaderRESTRequestMatcher();
+
+        $request = new Request([], [], [
+            'is_rest_request' => true,
+        ]);
+
+        self::assertFalse($matcher->matches($request));
+    }
+
+    public function testMatchesRestRequestsWithHeader(): void
+    {
+        $matcher = new AuthorizationHeaderRESTRequestMatcher();
+
+        $request = new Request([], [], [
+            'is_rest_request' => true,
+        ], [], [], [
+            'HTTP_AUTHORIZATION' => 'Bearer foo',
+        ]);
+
+        self::assertTrue($matcher->matches($request));
+    }
+}

--- a/tests/contracts/Security/AuthorizationHeaderRESTRequestMatcherTest.php
+++ b/tests/contracts/Security/AuthorizationHeaderRESTRequestMatcherTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [IBX-4259](https://issues.ibexa.co/browse/IBX-4359)
| **Type**| improvement
| **Target version** | `v4.3`
| **BC breaks**      | no
| **Tests pass**     | yes
| **Doc needed**     | yes

This PR adds an additional service `Ibexa\Contracts\Rest\Security\AuthorizationHeaderRESTRequestMatcher` that can be used instead of `Ibexa\AdminUi\REST\Security\NonAdminRESTRequestMatcher`. 

The original issue stems from the fact that once it has been set as JWT firewall request matcher, it matched every time a REST request was issued, preventing cookie based authentication from working with our REST API endpoint.

What I'm suggesting instead is to detect a token-based authentication attempt (+ token creation route access).

Then our `security.yaml` recipe will change to:
```yaml
# security.yaml
security:
    firewalls:
        # ...
        ibexa_jwt_rest:
            request_matcher: Ibexa\Contracts\Rest\Security\AuthorizationHeaderRESTRequestMatcher
            user_checker: Ibexa\Core\MVC\Symfony\Security\UserChecker
            anonymous: ~
            guard:
                authenticators:
                    - lexik_jwt_authentication.jwt_token_authenticator
                entry_point: lexik_jwt_authentication.jwt_token_authenticator
            stateless: true
```

## QA instructions
Install Ibexa DXP and replace the JWT recipe in `security.yaml` with the one above.

Ensure that both session authentication and JWT authentication work.

Ensure that features like Page Builder previews work without adjustments. 

**TODO**:
- [x] Implement tests.
- [x] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [x] Ask for Code Review.
