### PR TITLE
Fixed usage of deprecated string interpolation (PHP 8.2)

### DIFF
--- a/src/lib/Server/Input/Parser/Criterion.php
+++ b/src/lib/Server/Input/Parser/Criterion.php
@@ -64,7 +64,7 @@ abstract class Criterion extends BaseParser
         try {
             return $parsingDispatcher->parse([$facetBuilderName => $facetBuilderData], $mediaType);
         } catch (Exceptions\Parser $e) {
-            throw new Exceptions\Parser("Invalid FacetBuilder id <${facetBuilderName}>", 0, $e);
+            throw new Exceptions\Parser("Invalid FacetBuilder id <$facetBuilderName>", 0, $e);
         }
     }
 


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     |
| **Type**| improvement
| **Target version** |
| **BC breaks**      | no
| **Tests pass**     | no
| **Doc needed**     | no

<!-- Replace this comment with Pull Request description -->

**TODO**:
- [ ] Implement tests.
- [ ] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [ ] Ask for Code Review.
