### PR TITLE
IBX-5024: Fixed CSRF source for UserSession response in `/user/session/check` endpoint

### DIFF
--- a/src/lib/Server/Controller/SessionController.php
+++ b/src/lib/Server/Controller/SessionController.php
@@ -160,7 +160,7 @@ class SessionController extends Controller
             $currentUser,
             $session->getName(),
             $session->getId(),
-            $request->headers->get('X-CSRF-Token'),
+            $this->getCsrfToken(),
             false
         );
     }


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [IBX-5024](https://issues.ibexa.co/browse/IBX-5024)
| **Type**| bug
| **Target version** | `v4.4`
| **BC breaks**      | no
| **Tests pass**     | yes
| **Doc needed**     | no

Fixes an issue where instead of providing the user with a valid CSRF token when `UserSession` is returned, we were simply passing the header value back.

**TODO**:
- [x] ~Implement tests~.
- [x] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [x] Ask for Code Review.
