### PR TITLE
IBX-5025: Added `token` property to JWT response as object value

### DIFF
--- a/src/lib/Server/Output/ValueObjectVisitor/JWT.php
+++ b/src/lib/Server/Output/ValueObjectVisitor/JWT.php
@@ -20,8 +20,8 @@ final class JWT extends ValueObjectVisitor
         $visitor->setHeader('Content-Type', $generator->getMediaType('JWT'));
 
         $generator->startObjectElement('JWT');
-        $generator->startAttribute('token', $data->token);
-        $generator->endAttribute('token');
+        $generator->attribute('token', $data->token);
+        $generator->valueElement('token', $data->token);
         $generator->endObjectElement('JWT');
     }
 }


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [IBX-5025](https://issues.ibexa.co/browse/IBX-5025)
| **Type**| improvement
| **Target version** | `v4.4`
| **BC breaks**      | no
| **Tests pass**     | yes
| **Doc needed**     | yes (REST API changes)

When responding to JWT endpoint, response contains token as an attribute:

```xml
<JWT token="value" />
```
or property prefixed with underscore
```json
{
    "JWT": {
        "_token": "value"
    }
}
```
Given that token is an integral and important part of response, it should be passed as value:
```xml
<JWT>
    <token>value</token>
</JWT>
```
or
```json
{
    "JWT": {
        "token": "value",
    }
}
```
(old property `_token` is retained for BC)

**TODO**:
- [x] Implement tests.
- [x] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [x] Ask for Code Review.
