### PR TITLE
IBX-5027: Added logging exceptions for REST

### DIFF
--- a/src/bundle/EventListener/ResponseListener.php
+++ b/src/bundle/EventListener/ResponseListener.php
@@ -15,6 +15,7 @@ use Symfony\Component\HttpKernel\Event\ExceptionEvent;
 use Symfony\Component\HttpKernel\Event\ViewEvent;
 use Symfony\Component\HttpKernel\Exception\HttpExceptionInterface;
 use Symfony\Component\HttpKernel\KernelEvents;
+use Throwable;
 
 /**
  * REST Response Listener.
@@ -90,7 +91,7 @@ class ResponseListener implements EventSubscriberInterface, LoggerAwareInterface
         );
     }
 
-    private function logException(\Throwable $exception): void
+    private function logException(Throwable $exception): void
     {
         if (!isset($this->logger)) {
             return;

--- a/src/bundle/EventListener/ResponseListener.php
+++ b/src/bundle/EventListener/ResponseListener.php
@@ -7,9 +7,13 @@
 namespace Ibexa\Bundle\Rest\EventListener;
 
 use Ibexa\Rest\Server\View\AcceptHeaderVisitorDispatcher;
+use Psr\Log\LoggerAwareInterface;
+use Psr\Log\LoggerAwareTrait;
+use Psr\Log\LogLevel;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\HttpKernel\Event\ExceptionEvent;
 use Symfony\Component\HttpKernel\Event\ViewEvent;
+use Symfony\Component\HttpKernel\Exception\HttpExceptionInterface;
 use Symfony\Component\HttpKernel\KernelEvents;
 
 /**
@@ -17,8 +21,10 @@ use Symfony\Component\HttpKernel\KernelEvents;
  *
  * Converts responses from REST controllers to REST Responses, depending on the Accept-Header value.
  */
-class ResponseListener implements EventSubscriberInterface
+class ResponseListener implements EventSubscriberInterface, LoggerAwareInterface
 {
+    use LoggerAwareTrait;
+
     /**
      * @var \Ibexa\Rest\Server\View\AcceptHeaderVisitorDispatcher
      */
@@ -73,13 +79,31 @@ class ResponseListener implements EventSubscriberInterface
             return;
         }
 
+        $exception = $event->getThrowable();
+        $this->logException($exception);
+
         $event->setResponse(
             $this->viewDispatcher->dispatch(
                 $event->getRequest(),
-                $event->getThrowable()
+                $exception
             )
         );
-        $event->stopPropagation();
+    }
+
+    private function logException(\Throwable $exception): void
+    {
+        if (!isset($this->logger)) {
+            return;
+        }
+
+        $logLevel = LogLevel::ERROR;
+        if (!$exception instanceof HttpExceptionInterface || $exception->getStatusCode() >= 500) {
+            $logLevel = LogLevel::CRITICAL;
+        }
+
+        $this->logger->log($logLevel, $exception->getMessage(), [
+            'exception' => $exception,
+        ]);
     }
 }
 

--- a/src/bundle/Resources/config/services.yml
+++ b/src/bundle/Resources/config/services.yml
@@ -188,8 +188,11 @@ services:
     Ibexa\Bundle\Rest\EventListener\ResponseListener:
         arguments:
             - '@Ibexa\Rest\Server\View\AcceptHeaderVisitorDispatcher'
+        calls:
+            - ['setLogger', ['@?logger']]
         tags:
             - { name: kernel.event_subscriber }
+            - { name: monolog.logger, channel: request }
 
     Ibexa\Bundle\Rest\EventListener\CsrfListener:
         arguments:


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [IBX-5027](https://issues.ibexa.co/browse/IBX-5027)
| **Type**| improvement
| **Target version** | `v4.4`
| **BC breaks**      | no
| **Tests pass**     | yes
| **Doc needed**     | no

Our REST API does not log exceptions when they occur, making it harder to debug requests.

While it is possible to read stacktrace in th REST response, it is cumbersome and requires response to actually remain somewhere (which might not always be the case).

Instead, I suggest we log exceptions in a similar fashion as built-in Symfony's ErrorListener service does it.

Ideally, we would simply allow ErrorListener to run and log exceptions this way (it registers itself with priority 0 and -128, for logging and generating response respectively), but that would be a BC break on our side, because we would need to change several service priorities - which might mess up our users configurations, if they rely on us having exception listeners with specific priorities.

Currently:
![image](https://user-images.githubusercontent.com/3183926/216986476-0c70095d-5948-4603-ad36-c4d16685cf5e.png)
I would expect to have instead:
![image](https://user-images.githubusercontent.com/3183926/216986530-08e0e7d9-517a-48a9-8eb4-bb55cfaecd60.png)

**TODO**:
- [x] Implement tests.
- [x] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [x] Ask for Code Review.
