### PR TITLE
IBX-5044: Fixed DateMetadata criterion failure in XML REST API

### DIFF
--- a/src/lib/Server/Input/Parser/Criterion/DateMetadata.php
+++ b/src/lib/Server/Input/Parser/Criterion/DateMetadata.php
@@ -37,7 +37,7 @@ class DateMetadata extends BaseParser
     public function parse(array $data, ParsingDispatcher $parsingDispatcher): DateMetadataCriterion
     {
         if (!isset($data['DateMetadataCriterion'])) {
-            throw new Exceptions\Parser('Invalid <DateMetaDataCriterion> format');
+            throw new Exceptions\Parser('Invalid <DateMetadataCriterion> format');
         }
 
         $dateMetadata = $data['DateMetadataCriterion'];
@@ -54,6 +54,14 @@ class DateMetadata extends BaseParser
 
         if (!isset($dateMetadata['Value'])) {
             throw new Exceptions\Parser('Invalid <Value> format');
+        }
+
+        if (
+            is_string($dateMetadata['Value'])
+            && is_numeric($dateMetadata['Value'])
+            && ((int)$dateMetadata['Value'] == $dateMetadata['Value'])
+        ) {
+            $dateMetadata['Value'] = (int)$dateMetadata['Value'];
         }
 
         if (!in_array(gettype($dateMetadata['Value']), ['integer', 'array'], true)) {

--- a/tests/lib/Server/Input/Parser/Criterion/DateMetadataTest.php
+++ b/tests/lib/Server/Input/Parser/Criterion/DateMetadataTest.php
@@ -34,6 +34,10 @@ final class DateMetadataTest extends BaseTest
                 new DateMetadataCriterion('created', Operator::EQ, 14),
             ],
             [
+                ['DateMetadataCriterion' => ['Target' => 'created', 'Value' => '14', 'Operator' => 'EQ']],
+                new DateMetadataCriterion('created', Operator::EQ, 14),
+            ],
+            [
                 ['DateMetadataCriterion' => ['Target' => 'created', 'Value' => 1620739489, 'Operator' => 'LT']],
                 new DateMetadataCriterion('created', Operator::LT, 1620739489),
             ],

--- a/tests/lib/Server/Input/Parser/Criterion/DateMetadataTest.php
+++ b/tests/lib/Server/Input/Parser/Criterion/DateMetadataTest.php
@@ -68,7 +68,7 @@ final class DateMetadataTest extends BaseTest
 
     public function testParseExceptionOnInvalidCriterionFormat(): void
     {
-        $this->expectExceptionMessage('Invalid <DateMetaDataCriterion> format');
+        $this->expectExceptionMessage('Invalid <DateMetadataCriterion> format');
         $this->expectException(Exceptions\Parser::class);
         $inputArray = [
             'foo' => 'Michael learns to mock',


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [IBX-5044](https://issues.ibexa.co/browse/IBX-5044)
| **Type**| bug
| **Target version** | `v4.4`
| **BC breaks**      | no
| **Tests pass**     | yes
| **Doc needed**     | no

Issue discovered when trying to provide a sample for:
https://github.com/ezsystems/developer-documentation/pull/1857


The following request towards /views endpoint will fail due to `DateMetadataCriterion.Value` being passed as string from the XML decoding service:
```xml
<?xml version="1.0" encoding="UTF-8"?>
<ViewInput>
  <identifier>TitleView</identifier>
  <Query>
    <Filter>
      <DateMetadataCriterion>
        <Target>modified</Target>
        <Value>1675681020</Value>
        <Operator>gte</Operator>
      </DateMetadataCriterion>
    </Filter>
    <limit>10</limit>
    <offset>0</offset>
    <SortClauses>
      <ContentName>ascending</ContentName>
    </SortClauses>
  </Query>
</ViewInput>
```

Results in:
```json
{
  "ErrorMessage": {
    "_media-type": "application\/vnd.ibexa.api.ErrorMessage+json",
    "errorCode": 400,
    "errorMessage": "Bad Request",
    "errorDescription": "Invalid Criterion id <DateMetadataCriterion> in <AND>",
    "trace": "...",
    "file": "\/home\/pniedzielski\/PhpstormProjects\/rest\/src\/lib\/Server\/Input\/Parser\/Criterion.php",
    "line": 45,
    "Previous": {
      "_media-type": "application\/vnd.ibexa.api.ErrorMessage+json",
      "ErrorMessage": {
        "_media-type": "application\/vnd.ibexa.api.ErrorMessage+json",
        "errorCode": 400,
        "errorMessage": "Bad Request",
        "errorDescription": "Invalid <Value> format",
        "trace": "..."
        "file": "\/home\/pniedzielski\/PhpstormProjects\/rest\/src\/lib\/Server\/Input\/Parser\/Criterion\/DateMetadata.php",
        "line": 68
      }
    }
  }
}
```

**TODO**:
- [x] Implement tests.
- [x] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [x] Ask for Code Review.
