### PR TITLE
Fixed deprecation notices in string interpolation with PHP 8.2

### DIFF
--- a/src/lib/Server/Input/Parser/Criterion.php
+++ b/src/lib/Server/Input/Parser/Criterion.php
@@ -64,7 +64,7 @@ abstract class Criterion extends BaseParser
         try {
             return $parsingDispatcher->parse([$facetBuilderName => $facetBuilderData], $mediaType);
         } catch (Exceptions\Parser $e) {
-            throw new Exceptions\Parser("Invalid FacetBuilder id <${facetBuilderName}>", 0, $e);
+            throw new Exceptions\Parser("Invalid FacetBuilder id <$facetBuilderName>", 0, $e);
         }
     }
 


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     |
| **Type**| improvement
| **Target version** | e.g.: Ibexa `v4.3`
| **BC breaks**      | no
| **Tests pass**     | yes
| **Doc needed**     | no

Fixes new PHP 8.2 deprecation notices:
`Deprecated: Using ${var} in strings is deprecated, use {$var} instead in ...`

**TODO**:
- [ ] Implement tests.
- [x] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [ ] Ask for Code Review.
