### PR TITLE
IBX-5296: Added REST serializer service

### DIFF
--- a/src/bundle/Resources/config/services.yml
+++ b/src/bundle/Resources/config/services.yml
@@ -325,7 +325,12 @@ services:
         calls:
             - [ setFormatOutput, [ "%kernel.debug%" ] ]
 
-    Ibexa\Rest\Output\Generator\Json\FieldTypeHashGenerator: ~
+    Ibexa\Rest\Output\Generator\Json\FieldTypeHashGenerator:
+        arguments:
+            $normalizer: '@ibexa.rest.serializer'
+            $logger: '@logger'
+        tags:
+            - { name: monolog.logger, channel: ibexa.rest }
 
     # value objects visitors
     Ibexa\Contracts\Rest\Output\ValueObjectVisitorDispatcher: ~

--- a/src/bundle/Resources/config/services.yml
+++ b/src/bundle/Resources/config/services.yml
@@ -15,6 +15,7 @@ services:
 
     ibexa.rest.serializer:
         class: Symfony\Component\Serializer\Serializer
+        autoconfigure: false
         factory: [ '@Ibexa\Bundle\Rest\Serializer\SerializerFactory', 'create' ]
 
     Ibexa\Bundle\Rest\Routing\OptionsLoader:

--- a/src/bundle/Resources/config/services.yml
+++ b/src/bundle/Resources/config/services.yml
@@ -8,6 +8,15 @@ parameters:
         - '(^.*/.*$)'
 
 services:
+    Ibexa\Bundle\Rest\Serializer\SerializerFactory:
+        arguments:
+            - !tagged_iterator 'ibexa.rest.serializer.normalizer'
+            - !tagged_iterator 'ibexa.rest.serializer.encoder'
+
+    ibexa.rest.serializer:
+        class: Symfony\Component\Serializer\Serializer
+        factory: [ '@Ibexa\Bundle\Rest\Serializer\SerializerFactory', 'create' ]
+
     Ibexa\Bundle\Rest\Routing\OptionsLoader:
         arguments:
             - '@Ibexa\Bundle\Rest\Routing\OptionsLoader\RouteCollectionMapper'

--- a/src/bundle/Resources/config/services.yml
+++ b/src/bundle/Resources/config/services.yml
@@ -317,7 +317,12 @@ services:
         calls:
             - [ setFormatOutput, [ "%kernel.debug%" ] ]
 
-    Ibexa\Rest\Output\Generator\Xml\FieldTypeHashGenerator: ~
+    Ibexa\Rest\Output\Generator\Xml\FieldTypeHashGenerator:
+        arguments:
+            $normalizer: '@ibexa.rest.serializer'
+            $logger: '@logger'
+        tags:
+            - { name: monolog.logger, channel: ibexa.rest }
 
     Ibexa\Rest\Output\Generator\Json:
         arguments:

--- a/src/bundle/Serializer/SerializerFactory.php
+++ b/src/bundle/Serializer/SerializerFactory.php
@@ -1,0 +1,50 @@
+<?php
+
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace Ibexa\Bundle\Rest\Serializer;
+
+use Symfony\Component\Serializer\Serializer;
+use Traversable;
+
+final class SerializerFactory
+{
+    /**
+     * @var iterable<\Symfony\Component\Serializer\Normalizer\NormalizerInterface|\Symfony\Component\Serializer\Normalizer\DenormalizerInterface>
+     */
+    private $normalizers;
+
+    /**
+     * @var iterable<\Symfony\Component\Serializer\Encoder\EncoderInterface|\Symfony\Component\Serializer\Encoder\DecoderInterface>
+     */
+    private $encoders;
+
+    /**
+     * @param iterable<\Symfony\Component\Serializer\Normalizer\NormalizerInterface|\Symfony\Component\Serializer\Normalizer\DenormalizerInterface> $normalizers
+     * @param iterable<\Symfony\Component\Serializer\Encoder\EncoderInterface|\Symfony\Component\Serializer\Encoder\DecoderInterface> $encoders
+     */
+    public function __construct(iterable $normalizers, iterable $encoders)
+    {
+        $this->normalizers = $normalizers;
+        $this->encoders = $encoders;
+    }
+
+    public function create(): Serializer
+    {
+        $normalizers = $this->normalizers;
+        if ($normalizers instanceof Traversable) {
+            $normalizers = iterator_to_array($normalizers);
+        }
+
+        $encoders = $this->encoders;
+        if ($encoders instanceof Traversable) {
+            $encoders = iterator_to_array($encoders);
+        }
+
+        return new Serializer($normalizers, $encoders);
+    }
+}

--- a/src/bundle/Serializer/SerializerFactory.php
+++ b/src/bundle/Serializer/SerializerFactory.php
@@ -16,12 +16,12 @@ final class SerializerFactory
     /**
      * @var iterable<\Symfony\Component\Serializer\Normalizer\NormalizerInterface|\Symfony\Component\Serializer\Normalizer\DenormalizerInterface>
      */
-    private $normalizers;
+    private iterable $normalizers;
 
     /**
      * @var iterable<\Symfony\Component\Serializer\Encoder\EncoderInterface|\Symfony\Component\Serializer\Encoder\DecoderInterface>
      */
-    private $encoders;
+    private iterable $encoders;
 
     /**
      * @param iterable<\Symfony\Component\Serializer\Normalizer\NormalizerInterface|\Symfony\Component\Serializer\Normalizer\DenormalizerInterface> $normalizers

--- a/src/lib/Output/Generator/Json/FieldTypeHashGenerator.php
+++ b/src/lib/Output/Generator/Json/FieldTypeHashGenerator.php
@@ -61,24 +61,7 @@ class FieldTypeHashGenerator implements LoggerAwareInterface
         }
 
         if (is_object($value)) {
-            try {
-                $value = $this->normalizer->normalize($value, 'json', ['parent' => $parent]);
-            } catch (ExceptionInterface $e) {
-                $message = sprintf(
-                    'Unable to normalize value for type "%s". %s. '
-                    . 'Ensure that a normalizer is registered with tag: "%s".',
-                    get_class($value),
-                    $e->getMessage(),
-                    'ibexa.rest.serializer.normalizer',
-                );
-                $this->logger->error($message, [
-                    'exception' => $e,
-                ]);
-
-                $value = null;
-            }
-
-            return $this->generateValue($parent, $value);
+            return $this->generateObjectValue($parent, $value);
         }
 
         throw new \Exception('Invalid type in Field value hash: ' . get_debug_type($value));
@@ -157,6 +140,33 @@ class FieldTypeHashGenerator implements LoggerAwareInterface
         }
 
         return true;
+    }
+
+    /**
+     * @param \Ibexa\Rest\Output\Generator\Json\ArrayObject|\Ibexa\Rest\Output\Generator\Json\JsonObject $parent
+     *
+     * @return mixed
+     */
+    private function generateObjectValue($parent, object $value)
+    {
+        try {
+            $value = $this->normalizer->normalize($value, 'json', ['parent' => $parent]);
+        } catch (ExceptionInterface $e) {
+            $message = sprintf(
+                'Unable to normalize value for type "%s". %s. '
+                . 'Ensure that a normalizer is registered with tag: "%s".',
+                get_class($value),
+                $e->getMessage(),
+                'ibexa.rest.serializer.normalizer',
+            );
+            $this->logger->error($message, [
+                'exception' => $e,
+            ]);
+
+            $value = null;
+        }
+
+        return $this->generateValue($parent, $value);
     }
 }
 

--- a/src/lib/Output/Generator/Json/FieldTypeHashGenerator.php
+++ b/src/lib/Output/Generator/Json/FieldTypeHashGenerator.php
@@ -65,9 +65,10 @@ class FieldTypeHashGenerator implements LoggerAwareInterface
                 $value = $this->normalizer->normalize($value, 'json', ['parent' => $parent]);
             } catch (ExceptionInterface $e) {
                 $message = sprintf(
-                    'Unable to normalize value for type "%s". '
+                    'Unable to normalize value for type "%s". %s. '
                     . 'Ensure that a normalizer is registered with tag: "%s".',
-                    get_debug_type($value),
+                    get_class($value),
+                    $e->getMessage(),
                     'ibexa.rest.serializer.normalizer',
                 );
                 $this->logger->error($message, [

--- a/src/lib/Output/Generator/Json/FieldTypeHashGenerator.php
+++ b/src/lib/Output/Generator/Json/FieldTypeHashGenerator.php
@@ -51,6 +51,11 @@ class FieldTypeHashGenerator implements LoggerAwareInterface
      */
     protected function generateValue($parent, $value)
     {
+        if (is_scalar($value)) {
+            // Will be handled accordingly on serialization
+            return $value;
+        }
+
         if (is_array($value)) {
             return $this->generateArrayValue($parent, $value);
         }
@@ -73,8 +78,7 @@ class FieldTypeHashGenerator implements LoggerAwareInterface
             }
         }
 
-        // Will be handled accordingly on serialization
-        return $value;
+        throw new \Exception('Invalid type in Field value hash: ' . get_debug_type($value));
     }
 
     /**

--- a/src/lib/Output/Generator/Json/FieldTypeHashGenerator.php
+++ b/src/lib/Output/Generator/Json/FieldTypeHashGenerator.php
@@ -62,7 +62,7 @@ class FieldTypeHashGenerator implements LoggerAwareInterface
 
         if (is_object($value)) {
             try {
-                return $this->normalizer->normalize($value, 'json', ['parent' => $parent]);
+                $value = $this->normalizer->normalize($value, 'json', ['parent' => $parent]);
             } catch (ExceptionInterface $e) {
                 $message = sprintf(
                     'Unable to normalize value for type "%s". '
@@ -74,8 +74,10 @@ class FieldTypeHashGenerator implements LoggerAwareInterface
                     'exception' => $e,
                 ]);
 
-                return null;
+                $value = null;
             }
+
+            return $this->generateValue($parent, $value);
         }
 
         throw new \Exception('Invalid type in Field value hash: ' . get_debug_type($value));

--- a/src/lib/Output/Generator/Json/FieldTypeHashGenerator.php
+++ b/src/lib/Output/Generator/Json/FieldTypeHashGenerator.php
@@ -10,7 +10,7 @@ use Psr\Log\LoggerAwareInterface;
 use Psr\Log\LoggerAwareTrait;
 use Psr\Log\LoggerInterface;
 use Psr\Log\NullLogger;
-use Symfony\Component\Serializer\Exception\NotNormalizableValueException;
+use Symfony\Component\Serializer\Exception\ExceptionInterface;
 use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
 
 class FieldTypeHashGenerator implements LoggerAwareInterface
@@ -58,7 +58,7 @@ class FieldTypeHashGenerator implements LoggerAwareInterface
         if (is_object($value)) {
             try {
                 return $this->normalizer->normalize($value, 'json', ['parent' => $parent]);
-            } catch (NotNormalizableValueException $e) {
+            } catch (ExceptionInterface $e) {
                 $message = sprintf(
                     'Unable to normalize value for type "%s". '
                     . 'Ensure that a normalizer is registered with tag: "%s".',

--- a/src/lib/Output/Generator/Json/FieldTypeHashGenerator.php
+++ b/src/lib/Output/Generator/Json/FieldTypeHashGenerator.php
@@ -51,7 +51,7 @@ class FieldTypeHashGenerator implements LoggerAwareInterface
      */
     protected function generateValue($parent, $value)
     {
-        if (is_scalar($value)) {
+        if ($value === null || is_scalar($value)) {
             // Will be handled accordingly on serialization
             return $value;
         }

--- a/src/lib/Output/Generator/Xml/FieldTypeHashGenerator.php
+++ b/src/lib/Output/Generator/Xml/FieldTypeHashGenerator.php
@@ -63,22 +63,7 @@ class FieldTypeHashGenerator implements LoggerAwareInterface
         } elseif (is_array($value)) {
             $this->generateArrayValue($writer, $value, $key, $elementName);
         } elseif (is_object($value)) {
-            try {
-                $value = $this->normalizer->normalize($value, 'xml');
-            } catch (ExceptionInterface $e) {
-                $message = sprintf(
-                    'Unable to normalize value for type "%s". %s. '
-                    . 'Ensure that a normalizer is registered with tag: "%s".',
-                    get_class($value),
-                    $e->getMessage(),
-                    'ibexa.rest.serializer.normalizer',
-                );
-                $this->logger->error($message, [
-                    'exception' => $e,
-                ]);
-                $value = null;
-            }
-            $this->generateValue($writer, $value, $key, $elementName);
+            $this->generateObjectValue($value, $writer, $key, $elementName);
         } else {
             throw new \Exception('Invalid type in Field value hash: ' . get_debug_type($value));
         }
@@ -251,6 +236,26 @@ class FieldTypeHashGenerator implements LoggerAwareInterface
             $writer->text($key);
             $writer->endAttribute();
         }
+    }
+
+    private function generateObjectValue(object $value, \XmlWriter $writer, ?string $key, string $elementName): void
+    {
+        try {
+            $value = $this->normalizer->normalize($value, 'xml');
+        } catch (ExceptionInterface $e) {
+            $message = sprintf(
+                'Unable to normalize value for type "%s". %s. '
+                . 'Ensure that a normalizer is registered with tag: "%s".',
+                get_class($value),
+                $e->getMessage(),
+                'ibexa.rest.serializer.normalizer',
+            );
+            $this->logger->error($message, [
+                'exception' => $e,
+            ]);
+            $value = null;
+        }
+        $this->generateValue($writer, $value, $key, $elementName);
     }
 }
 

--- a/src/lib/Output/Generator/Xml/FieldTypeHashGenerator.php
+++ b/src/lib/Output/Generator/Xml/FieldTypeHashGenerator.php
@@ -78,11 +78,10 @@ class FieldTypeHashGenerator implements LoggerAwareInterface
                 $value = [];
             }
             $this->generateArrayValue($writer, $value, $key, $elementName);
-
-            return;
+        } else {
+            throw new \Exception('Invalid type in Field value hash: ' . get_debug_type($value));
         }
 
-        throw new \Exception('Invalid type in Field value hash: ' . get_debug_type($value));
     }
 
     /**

--- a/src/lib/Output/Generator/Xml/FieldTypeHashGenerator.php
+++ b/src/lib/Output/Generator/Xml/FieldTypeHashGenerator.php
@@ -6,8 +6,27 @@
  */
 namespace Ibexa\Rest\Output\Generator\Xml;
 
-class FieldTypeHashGenerator
+use Psr\Log\LoggerAwareInterface;
+use Psr\Log\LoggerAwareTrait;
+use Psr\Log\LoggerInterface;
+use Psr\Log\NullLogger;
+use Symfony\Component\Serializer\Exception\ExceptionInterface;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+
+class FieldTypeHashGenerator implements LoggerAwareInterface
 {
+    use LoggerAwareTrait;
+
+    private NormalizerInterface $normalizer;
+
+    public function __construct(
+        NormalizerInterface $normalizer,
+        ?LoggerInterface $logger = null
+    ) {
+        $this->normalizer = $normalizer;
+        $this->logger = $logger ?? new NullLogger();
+    }
+
     /**
      * Generates the field type value $hashValue into the $writer creating an
      * element with $hashElementName as its parent.
@@ -31,34 +50,39 @@ class FieldTypeHashGenerator
      */
     protected function generateValue(\XmlWriter $writer, $value, $key = null, $elementName = 'value')
     {
-        switch (($hashValueType = gettype($value))) {
-            case 'NULL':
-                $this->generateNullValue($writer, $key, $elementName);
-                break;
+        if ($value === null) {
+            $this->generateNullValue($writer, $key, $elementName);
+        } elseif (is_bool($value)) {
+            $this->generateBooleanValue($writer, $value, $key, $elementName);
+        } elseif (is_int($value)) {
+            $this->generateIntegerValue($writer, $value, $key, $elementName);
+        } elseif (is_float($value)) {
+            $this->generateFloatValue($writer, $value, $key, $elementName);
+        } elseif (is_string($value)) {
+            $this->generateStringValue($writer, $value, $key, $elementName);
+        } elseif (is_array($value)) {
+            $this->generateArrayValue($writer, $value, $key, $elementName);
+        } elseif (is_object($value)) {
+            try {
+                $value = $this->normalizer->normalize($value, 'xml');
+            } catch (ExceptionInterface $e) {
+                $message = sprintf(
+                    'Unable to normalize value for type "%s". '
+                    . 'Ensure that a normalizer is registered with tag: "%s".',
+                    get_class($value),
+                    'ibexa.rest.serializer.normalizer',
+                );
+                $this->logger->error($message, [
+                    'exception' => $e,
+                ]);
+                $value = [];
+            }
+            $this->generateArrayValue($writer, $value, $key, $elementName);
 
-            case 'boolean':
-                $this->generateBooleanValue($writer, $value, $key, $elementName);
-                break;
-
-            case 'integer':
-                $this->generateIntegerValue($writer, $value, $key, $elementName);
-                break;
-
-            case 'double':
-                $this->generateFloatValue($writer, $value, $key, $elementName);
-                break;
-
-            case 'string':
-                $this->generateStringValue($writer, $value, $key, $elementName);
-                break;
-
-            case 'array':
-                $this->generateArrayValue($writer, $value, $key, $elementName);
-                break;
-
-            default:
-                throw new \Exception('Invalid type in Field value hash: ' . $hashValueType);
+            return;
         }
+
+        throw new \Exception('Invalid type in Field value hash: ' . get_debug_type($value));
     }
 
     /**

--- a/src/lib/Output/Generator/Xml/FieldTypeHashGenerator.php
+++ b/src/lib/Output/Generator/Xml/FieldTypeHashGenerator.php
@@ -67,9 +67,10 @@ class FieldTypeHashGenerator implements LoggerAwareInterface
                 $value = $this->normalizer->normalize($value, 'xml');
             } catch (ExceptionInterface $e) {
                 $message = sprintf(
-                    'Unable to normalize value for type "%s". '
+                    'Unable to normalize value for type "%s". %s. '
                     . 'Ensure that a normalizer is registered with tag: "%s".',
                     get_class($value),
+                    $e->getMessage(),
                     'ibexa.rest.serializer.normalizer',
                 );
                 $this->logger->error($message, [

--- a/src/lib/Output/Generator/Xml/FieldTypeHashGenerator.php
+++ b/src/lib/Output/Generator/Xml/FieldTypeHashGenerator.php
@@ -75,7 +75,7 @@ class FieldTypeHashGenerator implements LoggerAwareInterface
                 $this->logger->error($message, [
                     'exception' => $e,
                 ]);
-                $value = [];
+                $value = null;
             }
             $this->generateValue($writer, $value, $key, $elementName);
         } else {

--- a/src/lib/Output/Generator/Xml/FieldTypeHashGenerator.php
+++ b/src/lib/Output/Generator/Xml/FieldTypeHashGenerator.php
@@ -77,11 +77,10 @@ class FieldTypeHashGenerator implements LoggerAwareInterface
                 ]);
                 $value = [];
             }
-            $this->generateArrayValue($writer, $value, $key, $elementName);
+            $this->generateValue($writer, $value, $key, $elementName);
         } else {
             throw new \Exception('Invalid type in Field value hash: ' . get_debug_type($value));
         }
-
     }
 
     /**

--- a/tests/lib/Output/Generator/FieldTypeHashGeneratorBaseTest.php
+++ b/tests/lib/Output/Generator/FieldTypeHashGeneratorBaseTest.php
@@ -51,11 +51,7 @@ abstract class FieldTypeHashGeneratorBaseTest extends TestCase
      */
     final protected function getNormalizer(): NormalizerInterface
     {
-        if (!isset($this->normalizer)) {
-            $this->normalizer = $this->createMock(NormalizerInterface::class);
-        }
-
-        return $this->normalizer;
+        return $this->normalizer ??= $this->createMock(NormalizerInterface::class);
     }
 
     public function testGenerateNull()

--- a/tests/lib/Output/Generator/FieldTypeHashGeneratorBaseTest.php
+++ b/tests/lib/Output/Generator/FieldTypeHashGeneratorBaseTest.php
@@ -242,7 +242,7 @@ abstract class FieldTypeHashGeneratorBaseTest extends TestCase
         $fixtureFile = $this->getFixtureFile($functionName);
         $actualResult = $this->getGeneratorOutput();
 
-        file_put_contents( $fixtureFile, $actualResult );
+        // file_put_contents( $fixtureFile, $actualResult );
         // $this->markTestIncomplete( "Wrote fixture to '{$fixtureFile}'." );
 
         $this->assertSame(

--- a/tests/lib/Output/Generator/Json/FieldTypeHashGeneratorTest.php
+++ b/tests/lib/Output/Generator/Json/FieldTypeHashGeneratorTest.php
@@ -17,7 +17,7 @@ class FieldTypeHashGeneratorTest extends FieldTypeHashGeneratorBaseTest
      */
     protected function initializeFieldTypeHashGenerator(): FieldTypeHashGenerator
     {
-        return new FieldTypeHashGenerator($this->getNormalizer());
+        return new FieldTypeHashGenerator($this->getNormalizer(), $this->getLogger());
     }
 
     /**

--- a/tests/lib/Output/Generator/Json/FieldTypeHashGeneratorTest.php
+++ b/tests/lib/Output/Generator/Json/FieldTypeHashGeneratorTest.php
@@ -9,7 +9,6 @@ namespace Ibexa\Tests\Rest\Output\Generator\Json;
 use Ibexa\Rest\Output\Generator\Json;
 use Ibexa\Rest\Output\Generator\Json\FieldTypeHashGenerator;
 use Ibexa\Tests\Rest\Output\Generator\FieldTypeHashGeneratorBaseTest;
-use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
 
 class FieldTypeHashGeneratorTest extends FieldTypeHashGeneratorBaseTest
 {

--- a/tests/lib/Output/Generator/Json/FieldTypeHashGeneratorTest.php
+++ b/tests/lib/Output/Generator/Json/FieldTypeHashGeneratorTest.php
@@ -9,30 +9,25 @@ namespace Ibexa\Tests\Rest\Output\Generator\Json;
 use Ibexa\Rest\Output\Generator\Json;
 use Ibexa\Rest\Output\Generator\Json\FieldTypeHashGenerator;
 use Ibexa\Tests\Rest\Output\Generator\FieldTypeHashGeneratorBaseTest;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
 
 class FieldTypeHashGeneratorTest extends FieldTypeHashGeneratorBaseTest
 {
     /**
      * Initializes the field type hash generator.
-     *
-     * @return \Ibexa\Rest\Output\Generator\Json\FieldTypeHashGenerator
      */
-    protected function initializeFieldTypeHashGenerator()
+    protected function initializeFieldTypeHashGenerator(): FieldTypeHashGenerator
     {
-        return new FieldTypeHashGenerator();
+        return new FieldTypeHashGenerator($this->createMock(NormalizerInterface::class));
     }
 
     /**
      * Initializes the generator.
-     *
-     * @return \Ibexa\Contracts\Rest\Output\Generator
      */
-    protected function initializeGenerator()
+    protected function initializeGenerator(): Json
     {
         return new Json(
             $this->getFieldTypeHashGenerator()
         );
     }
 }
-
-class_alias(FieldTypeHashGeneratorTest::class, 'EzSystems\EzPlatformRest\Tests\Output\Generator\Json\FieldTypeHashGeneratorTest');

--- a/tests/lib/Output/Generator/Json/FieldTypeHashGeneratorTest.php
+++ b/tests/lib/Output/Generator/Json/FieldTypeHashGeneratorTest.php
@@ -18,7 +18,7 @@ class FieldTypeHashGeneratorTest extends FieldTypeHashGeneratorBaseTest
      */
     protected function initializeFieldTypeHashGenerator(): FieldTypeHashGenerator
     {
-        return new FieldTypeHashGenerator($this->createMock(NormalizerInterface::class));
+        return new FieldTypeHashGenerator($this->getNormalizer());
     }
 
     /**

--- a/tests/lib/Output/Generator/Xml/FieldTypeHashGeneratorTest.php
+++ b/tests/lib/Output/Generator/Xml/FieldTypeHashGeneratorTest.php
@@ -9,6 +9,7 @@ namespace Ibexa\Tests\Rest\Output\Generator\Xml;
 use Ibexa\Rest\Output\Generator\Xml;
 use Ibexa\Rest\Output\Generator\Xml\FieldTypeHashGenerator;
 use Ibexa\Tests\Rest\Output\Generator\FieldTypeHashGeneratorBaseTest;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
 
 class FieldTypeHashGeneratorTest extends FieldTypeHashGeneratorBaseTest
 {
@@ -17,9 +18,9 @@ class FieldTypeHashGeneratorTest extends FieldTypeHashGeneratorBaseTest
      *
      * @return \Ibexa\Rest\Output\Generator\Xml\FieldTypeHashGenerator
      */
-    protected function initializeFieldTypeHashGenerator()
+    protected function initializeFieldTypeHashGenerator(): FieldTypeHashGenerator
     {
-        return new FieldTypeHashGenerator();
+        return new FieldTypeHashGenerator($this->createMock(NormalizerInterface::class));
     }
 
     /**

--- a/tests/lib/Output/Generator/Xml/FieldTypeHashGeneratorTest.php
+++ b/tests/lib/Output/Generator/Xml/FieldTypeHashGeneratorTest.php
@@ -9,26 +9,21 @@ namespace Ibexa\Tests\Rest\Output\Generator\Xml;
 use Ibexa\Rest\Output\Generator\Xml;
 use Ibexa\Rest\Output\Generator\Xml\FieldTypeHashGenerator;
 use Ibexa\Tests\Rest\Output\Generator\FieldTypeHashGeneratorBaseTest;
-use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
 
-class FieldTypeHashGeneratorTest extends FieldTypeHashGeneratorBaseTest
+final class FieldTypeHashGeneratorTest extends FieldTypeHashGeneratorBaseTest
 {
     /**
      * Initializes the field type hash generator.
-     *
-     * @return \Ibexa\Rest\Output\Generator\Xml\FieldTypeHashGenerator
      */
     protected function initializeFieldTypeHashGenerator(): FieldTypeHashGenerator
     {
-        return new FieldTypeHashGenerator($this->createMock(NormalizerInterface::class));
+        return new FieldTypeHashGenerator($this->getNormalizer());
     }
 
     /**
      * Initializes the generator.
-     *
-     * @return \Ibexa\Contracts\Rest\Output\Generator
      */
-    protected function initializeGenerator()
+    protected function initializeGenerator(): Xml
     {
         $generator = new Xml(
             $this->getFieldTypeHashGenerator()
@@ -38,5 +33,3 @@ class FieldTypeHashGeneratorTest extends FieldTypeHashGeneratorBaseTest
         return $generator;
     }
 }
-
-class_alias(FieldTypeHashGeneratorTest::class, 'EzSystems\EzPlatformRest\Tests\Output\Generator\Xml\FieldTypeHashGeneratorTest');

--- a/tests/lib/Output/Generator/Xml/FieldTypeHashGeneratorTest.php
+++ b/tests/lib/Output/Generator/Xml/FieldTypeHashGeneratorTest.php
@@ -17,7 +17,7 @@ final class FieldTypeHashGeneratorTest extends FieldTypeHashGeneratorBaseTest
      */
     protected function initializeFieldTypeHashGenerator(): FieldTypeHashGenerator
     {
-        return new FieldTypeHashGenerator($this->getNormalizer());
+        return new FieldTypeHashGenerator($this->getNormalizer(), $this->getLogger());
     }
 
     /**

--- a/tests/lib/Output/Generator/_fixtures/Json_FieldTypeHashGeneratorTest__testGenerateUsingNormalizer.out
+++ b/tests/lib/Output/Generator/_fixtures/Json_FieldTypeHashGeneratorTest__testGenerateUsingNormalizer.out
@@ -1,0 +1,1 @@
+{"Field":{"fieldValue":{"id":1,"type":"foo","internal_hash":{"foo":"bar"},"internal_list":[42,56]}}}

--- a/tests/lib/Output/Generator/_fixtures/Json_FieldTypeHashGeneratorTest__testGenerateWithMissingNormalizer.out
+++ b/tests/lib/Output/Generator/_fixtures/Json_FieldTypeHashGeneratorTest__testGenerateWithMissingNormalizer.out
@@ -1,0 +1,1 @@
+{"Field":{"fieldValue":null}}

--- a/tests/lib/Output/Generator/_fixtures/Xml_FieldTypeHashGeneratorTest__testGenerateUsingNormalizer.out
+++ b/tests/lib/Output/Generator/_fixtures/Xml_FieldTypeHashGeneratorTest__testGenerateUsingNormalizer.out
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Field>
+ <fieldValue>
+  <value key="id">1</value>
+  <value key="type">foo</value>
+  <value key="internal_hash">
+   <value key="foo">bar</value>
+  </value>
+  <value key="internal_list">
+   <value>42</value>
+   <value>56</value>
+  </value>
+ </fieldValue>
+</Field>

--- a/tests/lib/Output/Generator/_fixtures/Xml_FieldTypeHashGeneratorTest__testGenerateWithMissingNormalizer.out
+++ b/tests/lib/Output/Generator/_fixtures/Xml_FieldTypeHashGeneratorTest__testGenerateWithMissingNormalizer.out
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Field>
+ <fieldValue/>
+</Field>

--- a/tests/lib/Output/ValueObjectVisitorBaseTest.php
+++ b/tests/lib/Output/ValueObjectVisitorBaseTest.php
@@ -13,6 +13,7 @@ use Ibexa\Tests\Rest\AssertXmlTagTrait;
 use Ibexa\Tests\Rest\Server;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\RouterInterface;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
 
 abstract class ValueObjectVisitorBaseTest extends Server\BaseTest
 {
@@ -94,7 +95,9 @@ abstract class ValueObjectVisitorBaseTest extends Server\BaseTest
     {
         if (!isset($this->generator)) {
             $this->generator = new Generator\Xml(
-                new Generator\Xml\FieldTypeHashGenerator()
+                new Generator\Xml\FieldTypeHashGenerator(
+                    $this->createMock(NormalizerInterface::class)
+                )
             );
         }
 


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [IBX-5296](https://issues.ibexa.co/browse/IBX-5296)
| **Type**| improvement
| **Target version** | `v4.4`
| **BC breaks**      | no
| **Tests pass**     | yes
| **Doc needed**     | yes/no

This PR adds a new service: `ibexa.rest.serializer` (an instance of Symfony Serializer, dedicated for REST input/output).

My reasoning for this is as follows: we have expressed multiple times our desire to switch over from Visitors into Symfony Serializer for our REST API. While we cannot change the existing design (we cannot discard Visitors due to backwards compatibility promise at least), we could use Symfony Serializer for our new API's internally.

After all, our Generator currently requires an implementation of `Ibexa\Contracts\Rest\Output\Generator::generateFieldTypeHash()` method. This means that we can use the output of Symfony Normalizer (which Serializer is an instance of) to feed `generateFieldTypeHash()` as input.

Additionally, it fixes an issue that occurs when `folder` Content Type is marked as "SEO enabled", and a subsequent request is made to Content Type endpoint:
```shell
curl --request GET \
  --url 'https://<IBEXA-DXP-DOMAIN>/api/ibexa/v2/content/types?identifier=folder' \
  --header 'Accept: application/vnd.ibexa.api.ContentTypeList+json'
```
(note: `ContentTypeInfoList` is not affected)
```json
{
  "ErrorMessage": {
    "_media-type": "application\/vnd.ibexa.api.ErrorMessage+json",
    "errorCode": 500,
    "errorMessage": "Internal Server Error",
    "errorDescription": "Invalid type in Field value hash: object"
    // ...
}
```

**TODO**:
- [x] Implement tests.
- [x] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [x] Ask for Code Review.
