### PR TITLE
IBX-5985: Added ability to check user against "X-Expected-User" header

### DIFF
--- a/src/bundle/EventListener/UserCheckRequestListener.php
+++ b/src/bundle/EventListener/UserCheckRequestListener.php
@@ -68,7 +68,7 @@ final class UserCheckRequestListener implements EventSubscriberInterface, Logger
         }
 
         if ($expectedUserIdentifier !== $identifier) {
-            throw new UnexpectedUserException('Expectation failed. User changed.', 401);
+            throw new UnexpectedUserException('Expectation failed. User changed.', Response::HTTP_UNAUTHORIZED);
         }
     }
 }

--- a/src/bundle/EventListener/UserCheckRequestListener.php
+++ b/src/bundle/EventListener/UserCheckRequestListener.php
@@ -13,6 +13,7 @@ use Ibexa\Contracts\Core\Repository\PermissionResolver;
 use Psr\Log\LoggerAwareInterface;
 use Psr\Log\LoggerAwareTrait;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Event\RequestEvent;
 use Symfony\Component\HttpKernel\KernelEvents;
 use Symfony\Component\Security\Core\Security;
@@ -61,13 +62,7 @@ final class UserCheckRequestListener implements EventSubscriberInterface, Logger
             throw new UnexpectedUserException('Expectation failed. User changed.', 401);
         }
 
-        if (method_exists($user, 'getUserIdentifier')) {
-            $identifier = $user->getUserIdentifier();
-        } else {
-            $identifier = $user->getUsername();
-        }
-
-        if ($expectedUserIdentifier !== $identifier) {
+        if ($expectedUserIdentifier !== $user->getUsername()) {
             throw new UnexpectedUserException('Expectation failed. User changed.', Response::HTTP_UNAUTHORIZED);
         }
     }

--- a/src/bundle/EventListener/UserCheckRequestListener.php
+++ b/src/bundle/EventListener/UserCheckRequestListener.php
@@ -59,7 +59,7 @@ final class UserCheckRequestListener implements EventSubscriberInterface, Logger
 
         $user = $this->security->getUser();
         if ($user === null || $expectedUserIdentifier !== $user->getUsername()) {
-            throw new UnexpectedUserException('Expectation failed. User changed.', 401);
+            throw new UnexpectedUserException('Expectation failed. User changed.', Response::HTTP_UNAUTHORIZED);
         }
     }
 }

--- a/src/bundle/EventListener/UserCheckRequestListener.php
+++ b/src/bundle/EventListener/UserCheckRequestListener.php
@@ -58,12 +58,8 @@ final class UserCheckRequestListener implements EventSubscriberInterface, Logger
         }
 
         $user = $this->security->getUser();
-        if ($user === null) {
+        if ($user === null || $expectedUserIdentifier !== $user->getUsername()) {
             throw new UnexpectedUserException('Expectation failed. User changed.', 401);
-        }
-
-        if ($expectedUserIdentifier !== $user->getUsername()) {
-            throw new UnexpectedUserException('Expectation failed. User changed.', Response::HTTP_UNAUTHORIZED);
         }
     }
 }

--- a/src/bundle/EventListener/UserCheckRequestListener.php
+++ b/src/bundle/EventListener/UserCheckRequestListener.php
@@ -1,0 +1,74 @@
+<?php
+
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace Ibexa\Bundle\Rest\EventListener;
+
+use Ibexa\Bundle\Rest\Exception\UnexpectedUserException;
+use Ibexa\Contracts\Core\Repository\PermissionResolver;
+use Psr\Log\LoggerAwareInterface;
+use Psr\Log\LoggerAwareTrait;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\HttpKernel\Event\RequestEvent;
+use Symfony\Component\HttpKernel\KernelEvents;
+use Symfony\Component\Security\Core\Security;
+
+final class UserCheckRequestListener implements EventSubscriberInterface, LoggerAwareInterface
+{
+    use LoggerAwareTrait;
+
+    private PermissionResolver $permissionResolver;
+
+    private Security $security;
+
+    public function __construct(PermissionResolver $permissionResolver, Security $security)
+    {
+        $this->permissionResolver = $permissionResolver;
+        $this->security = $security;
+    }
+
+    public static function getSubscribedEvents(): array
+    {
+        return [
+            KernelEvents::REQUEST => [
+                ['checkUser'],
+            ],
+        ];
+    }
+
+    public function checkUser(RequestEvent $event): void
+    {
+        if (!$event->isMainRequest()) {
+            return;
+        }
+
+        if (!$event->getRequest()->attributes->get('is_rest_request')) {
+            return;
+        }
+
+        $request = $event->getRequest();
+        $expectedUserIdentifier = $request->headers->get('X-Expected-User');
+        if (empty($expectedUserIdentifier)) {
+            return;
+        }
+
+        $user = $this->security->getUser();
+        if ($user === null) {
+            throw new UnexpectedUserException('Expectation failed. User changed.', 401);
+        }
+
+        if (method_exists($user, 'getUserIdentifier')) {
+            $identifier = $user->getUserIdentifier();
+        } else {
+            $identifier = $user->getUsername();
+        }
+
+        if ($expectedUserIdentifier !== $identifier) {
+            throw new UnexpectedUserException('Expectation failed. User changed.', 401);
+        }
+    }
+}

--- a/src/bundle/Exception/UnexpectedUserException.php
+++ b/src/bundle/Exception/UnexpectedUserException.php
@@ -1,0 +1,15 @@
+<?php
+
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace Ibexa\Bundle\Rest\Exception;
+
+use Ibexa\Contracts\Core\Repository\Exceptions\UnauthorizedException;
+
+final class UnexpectedUserException extends UnauthorizedException
+{
+}

--- a/src/bundle/Resources/config/services.yml
+++ b/src/bundle/Resources/config/services.yml
@@ -214,6 +214,16 @@ services:
         tags:
             - { name: kernel.event_subscriber }
 
+    Ibexa\Bundle\Rest\EventListener\UserCheckRequestListener:
+        arguments:
+            $permissionResolver: '@Ibexa\Contracts\Core\Repository\PermissionResolver'
+            $security: '@security.helper'
+        calls:
+            - [setLogger, ['@logger']]
+        tags:
+            - { name: kernel.event_subscriber }
+            - { name: monolog.logger, channel: request }
+
     Ibexa\Rest\Server\Controller\Options:
         parent: Ibexa\Rest\Server\Controller
         tags: [controller.service_arguments]

--- a/tests/bundle/Functional/RootTest.php
+++ b/tests/bundle/Functional/RootTest.php
@@ -26,6 +26,29 @@ class RootTest extends RESTFunctionalTestCase
         return $response->getBody();
     }
 
+    public function testExpectedUser(): void
+    {
+        $request = $this->createHttpRequest('GET', '/api/ibexa/v2/');
+        $request = $request->withHeader('Accept', 'application/json');
+        $request = $request->withHeader('X-Expected-User', '');
+        $response = $this->sendHttpRequest($request);
+
+        self::assertHttpResponseCodeEquals($response, 200);
+
+        $request = $request->withHeader('X-Expected-User', 'admin');
+        $response = $this->sendHttpRequest($request);
+
+        self::assertHttpResponseCodeEquals($response, 200);
+
+        $request = $request->withHeader('X-Expected-User', 'foo');
+        $response = $this->sendHttpRequest($request);
+
+        self::assertHttpResponseCodeEquals($response, 401);
+        $responseArray = json_decode($response->getBody(), true, 512, JSON_THROW_ON_ERROR);
+        self::assertArrayHasKey('ErrorMessage', $responseArray);
+        self::assertSame('Expectation failed. User changed.', $responseArray['ErrorMessage']['errorDescription']);
+    }
+
     /**
      * @dataProvider getRandomUriSet
      * Covers GET /<wrongUri>


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [IBX-5985](https://issues.ibexa.co/browse/IBX-5985)
| **Type**| improvement
| **Target version** | `v4.5` (can be backported?)
| **BC breaks**      | no
| **Tests pass**     | yes
| **Doc needed**     | yes

This is PoC for handling of a special header to check that the user we are executing query with is the same as the REST client expects.

Handles cases where authentication has expired and we would otherwise receive a response for anonymous.

**TODO**:
- [x] Implement tests.
- [x] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [x] Ask for Code Review.
