### PR TITLE
IBX-4929: Removed `@internal param` PHPDoc from Output\Visitor

### DIFF
--- a/src/contracts/Output/Visitor.php
+++ b/src/contracts/Output/Visitor.php
@@ -44,8 +44,6 @@ class Visitor
      *
      * @param \Ibexa\Contracts\Rest\Output\Generator $generator
      * @param \Ibexa\Contracts\Rest\Output\ValueObjectVisitorDispatcher $valueObjectVisitorDispatcher
-     *
-     * {@internal param array $visitors}
      */
     public function __construct(Generator $generator, ValueObjectVisitorDispatcher $valueObjectVisitorDispatcher)
     {

--- a/src/contracts/Output/Visitor.php
+++ b/src/contracts/Output/Visitor.php
@@ -45,7 +45,7 @@ class Visitor
      * @param \Ibexa\Contracts\Rest\Output\Generator $generator
      * @param \Ibexa\Contracts\Rest\Output\ValueObjectVisitorDispatcher $valueObjectVisitorDispatcher
      *
-     * @internal param array $visitors
+     * {@internal param array $visitors}
      */
     public function __construct(Generator $generator, ValueObjectVisitorDispatcher $valueObjectVisitorDispatcher)
     {


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [IBX-4929](https://issues.ibexa.co/browse/IBX-4929)
| **Type**| improvement
| **Target version** | 4.5, 4.4
| **BC breaks**      | no
| **Tests pass**     | N/A
| **Doc needed**     | no

The constructor was tagged as internal with the reason/description "param array $visitors", and excluded from PHP API Reference. This tag came from https://github.com/ezsystems/ezpublish-kernel/commit/51c1dc69b3be6002ceb0d867ffb15a963fbea92a#diff-d48f139271422b1fb63677449e8437d409fd636de439aba5afcb5530a76c7a82R108

Meaningless tag removed to include the constructor into the reference.

https://docs.phpdoc.org/3.3/guide/references/phpdoc/tags/internal.html

**TODO**:
- [ ] Implement tests.
- [ ] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [x] Ask for Code Review.
