### PR TITLE
IBX-4929: Removed @internal from Controller\JWT

### DIFF
--- a/src/lib/Server/Controller/JWT.php
+++ b/src/lib/Server/Controller/JWT.php
@@ -18,9 +18,6 @@ use Lexik\Bundle\JWTAuthenticationBundle\Services\JWTTokenManagerInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Security\Core\Exception\AuthenticationException;
 
-/**
- * @internal
- */
 final class JWT extends RestController
 {
     /** @var \Lexik\Bundle\JWTAuthenticationBundle\Services\JWTTokenManagerInterface */


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [IBX-4929](https://issues.ibexa.co/browse/IBX-4929)
| **Type**| improvement
| **Target version** | 4.4+
| **BC breaks**      | no
| **Tests pass**     | n/a
| **Doc needed**     | no

The JWT controller is the only one in its namespace to be marked as internal and excluded from the PHPDoc.

The JWT controller has been marked as internal in https://github.com/kmadejski/ezplatform-rest/commit/0e809fe5ec9f612279b2ed56b06af83cc7f38e7b#diff-9c870b5da55481ce8b1de20af66b7b24e5352203473e50e814caab1b05c5b4a5R23 during https://github.com/ezsystems/ezplatform-rest/pull/54

* From a security POV, to document the JWT controller seems safe.
* From a developer POV, to have doc about the JWT controller might be useful.

**TODO**:
- [ ] Implement tests.
- [ ] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [ ] Ask for Code Review.
