### PR TITLE
PoC: Implemented Repository to REST Exception converters

### DIFF
--- a/src/bundle/Resources/config/exception/converters.yaml
+++ b/src/bundle/Resources/config/exception/converters.yaml
@@ -1,0 +1,11 @@
+services:
+    _defaults:
+        autowire: true
+        autoconfigure: true
+        public: false
+
+    _instanceof:
+        Ibexa\Rest\Exception\Converter\RepositoryExceptionConverterInterface:
+            tags: [ ibexa.rest.repository_exception.converter ]
+
+    Ibexa\Rest\Exception\Converter\ContentFieldValidationExceptionConverter: ~

--- a/src/bundle/Resources/config/services.yml
+++ b/src/bundle/Resources/config/services.yml
@@ -1,3 +1,6 @@
+imports:
+    - { resource: exception/converters.yaml }
+
 parameters:
     ibexa.rest.output.visitor.json.regexps:
         - '(^application/vnd\.ibexa\.api\.[A-Za-z]+\+json$)'
@@ -199,6 +202,7 @@ services:
     Ibexa\Bundle\Rest\EventListener\ResponseListener:
         arguments:
             - '@Ibexa\Rest\Server\View\AcceptHeaderVisitorDispatcher'
+            - '@Ibexa\Rest\Exception\Converter\RepositoryExceptionConverterInterface'
         calls:
             - ['setLogger', ['@?logger']]
         tags:
@@ -369,3 +373,10 @@ services:
         parent: hautelook.router.template
         calls:
             - [ setOption, [ strict_requirements, ~ ] ]
+
+    Ibexa\Rest\Exception\Converter\AggregateRepositoryExceptionConverter:
+        arguments:
+            $converters: !tagged_iterator ibexa.rest.repository_exception.converter
+
+    Ibexa\Rest\Exception\Converter\RepositoryExceptionConverterInterface:
+        alias: Ibexa\Rest\Exception\Converter\AggregateRepositoryExceptionConverter

--- a/src/lib/Exception/Converter/AggregateRepositoryExceptionConverter.php
+++ b/src/lib/Exception/Converter/AggregateRepositoryExceptionConverter.php
@@ -1,0 +1,45 @@
+<?php
+
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace Ibexa\Rest\Exception\Converter;
+
+use Ibexa\Contracts\Core\Repository\Exceptions\Exception as RepositoryException;
+use Ibexa\Rest\Server\Output\ValueObjectVisitor\Exception;
+use Throwable;
+
+/**
+ * @internal
+ */
+final class AggregateRepositoryExceptionConverter implements RepositoryExceptionConverterInterface
+{
+    /** @var iterable<RepositoryExceptionConverterInterface> */
+    private iterable $converters;
+
+    public function __construct(iterable $converters)
+    {
+        $this->converters = $converters;
+    }
+
+    public function convert(RepositoryException $exception): Throwable
+    {
+        foreach ($this->converters as $converter) {
+            if (!$converter->supports($exception)) {
+                continue;
+            }
+
+            return $converter->convert($exception);
+        }
+
+        return $exception;
+    }
+
+    public function supports(RepositoryException $exception): bool
+    {
+        return true;
+    }
+}

--- a/src/lib/Exception/Converter/ContentFieldValidationExceptionConverter.php
+++ b/src/lib/Exception/Converter/ContentFieldValidationExceptionConverter.php
@@ -1,0 +1,30 @@
+<?php
+
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace Ibexa\Rest\Exception\Converter;
+
+use Ibexa\Contracts\Core\Repository\Exceptions\ContentFieldValidationException as APIContentFieldValidationException;
+use Ibexa\Contracts\Core\Repository\Exceptions\Exception as RepositoryException;
+use Ibexa\Rest\Server\Exceptions\ContentFieldValidationException;
+use Throwable;
+
+final class ContentFieldValidationExceptionConverter implements RepositoryExceptionConverterInterface
+{
+    /**
+     * @param \Ibexa\Contracts\Core\Repository\Exceptions\ContentFieldValidationException $exception
+     */
+    public function convert(RepositoryException $exception): Throwable
+    {
+        return new ContentFieldValidationException($exception);
+    }
+
+    public function supports(RepositoryException $exception): bool
+    {
+        return $exception instanceof APIContentFieldValidationException;
+    }
+}

--- a/src/lib/Exception/Converter/RepositoryExceptionConverterInterface.php
+++ b/src/lib/Exception/Converter/RepositoryExceptionConverterInterface.php
@@ -1,0 +1,24 @@
+<?php
+
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace Ibexa\Rest\Exception\Converter;
+
+use Ibexa\Contracts\Core\Repository\Exceptions\Exception as RepositoryException;
+use Throwable;
+
+/**
+ * Convert Repository exceptions to their corresponding REST ValueObjectVisitor instances.
+ *
+ * @internal
+ */
+interface RepositoryExceptionConverterInterface
+{
+    public function convert(RepositoryException $exception): Throwable;
+
+    public function supports(RepositoryException $exception): bool;
+}


### PR DESCRIPTION
| Question                                  | Answer |
| ---------------------------------------- | ------------------ |
| **JIRA issue**                          | n/a
| **Type**                                   | improvement |
| **Target Ibexa version** | `v4.6` |
| **BC breaks**                          | no |

Ibexa REST defines a few of its own Exception classes and API Exception wrapper classes. In order for an API Exception to be rendered correctly as a response, it needs to be either wrapped with REST Exception which has its own Visitor or actually have dedicated Visitor. If we look at [`./src/bundle/Resources/config/value_object_visitors.yml`](src/bundle/Resources/config/value_object_visitors.yml) we will find a mix of those approaches.

Instead of trying to cover both REST and Repository API exceptions with one or two separate visitors, I suggest a new idea: **Repository Exception converter** which would map a Repository Exception into its REST counterpart.

As an example, `ContentFieldValidationExceptionConverter`, has been implemented to properly map Repository API `ContentFieldValidationException` to REST `ContentFieldValidationException`. This allows the following simplification of REST Controllers:

**Before:**

```php
public function updateCompanyAction(
    APICompany $company,
    RestCompanyUpdateStruct $companyUpdateStruct
): Company {
    try {
        $updatedCompany = $this->companyService->updateCompany(
            $company,
            $companyUpdateStruct->companyUpdateStruct
        );

        return new RestCompany($updatedCompany);
    } catch (APIContentFieldValidationException $e) {
        throw new RestContentFieldValidationException($e);
    }
}
```

**After:**

```php
public function updateCompanyAction(
    APICompany $company,
    RestCompanyUpdateStruct $companyUpdateStruct
): Company {
    $updatedCompany = $this->companyService->updateCompany(
        $company,
        $companyUpdateStruct->companyUpdateStruct
    );

    return new RestCompany($updatedCompany);
}
```

### Paths to explore
- [ ] Maybe introduce more generic extension point that would try to find converter for any non-REST exception, but there might be too much ambiguity to handle that.

### TODO
- [ ] Cover all RepositoryExceptions with proper Converters
- [ ] Remove DIC and visitor logic that now would be handled by Converters

#### Checklist:
- [x] Provided PR description.
- [x] Tested the solution manually.
- [ ] Provided automated test coverage.
- [x] Checked that target branch is set correctly
- [ ] Ran PHP CS Fixer for new PHP code (use `$ composer fix-cs`).
- [ ] Asked for a review