### PR TITLE
[Composer][DX] Changed order of namespace auto-loading

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,11 +8,11 @@
     },
     "autoload": {
         "psr-4": {
-            "EzSystems\\EzPlatformRestBundle\\": "src/bundle/",
-            "EzSystems\\EzPlatformRest\\": "src/lib/",
             "Ibexa\\Bundle\\Rest\\": "src/bundle/",
             "Ibexa\\Rest\\": "src/lib/",
-            "Ibexa\\Contracts\\Rest\\": "src/contracts/"
+            "Ibexa\\Contracts\\Rest\\": "src/contracts/",
+            "EzSystems\\EzPlatformRestBundle\\": "src/bundle/",
+            "EzSystems\\EzPlatformRest\\": "src/lib/"
         }
     },
     "autoload-dev": {


### PR DESCRIPTION
| Question                                  | Answer |
| ---------------------------------------- | ------------------ |
| **JIRA issue**                          | n/a |
| **Type**                                   | improvement |
| **Target Ibexa version** | `v4.5`+ |
| **BC breaks**                          | no |

We have incorrect order of PSR-4 auto-loading of namespaces, putting legacy one, currently used for BC as the first one. While it doesn't affect the production code, it affects DX as PHPStorm doesn't seem to understand having multiple namespaces for one directory and expects the first one encountered. Additionally when creating new classes, it tries to use old namespace.

#### Checklist:
- [x] Provided PR description.
- [x] Tested the solution manually.
- [ ] Provided automated test coverage.
- [x] Checked that target branch is set correctly (main for features, the oldest supported for bugs).
- [ ] Ran PHP CS Fixer for new PHP code.
- [ ] Asked for a review.
