### PR TITLE
Fixed PHPStan baseline for 4.6

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -481,19 +481,9 @@ parameters:
 			path: src/contracts/Output/Generator.php
 
 		-
-			message: "#^Method Ibexa\\\\Contracts\\\\Rest\\\\Output\\\\Generator\\:\\:startValueElement\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: src/contracts/Output/Generator.php
-
-		-
 			message: "#^Property Ibexa\\\\Contracts\\\\Rest\\\\Output\\\\Generator\\:\\:\\$stack type has no value type specified in iterable type array\\.$#"
 			count: 1
 			path: src/contracts/Output/Generator.php
-
-		-
-			message: "#^Method Ibexa\\\\Contracts\\\\Rest\\\\Output\\\\Generator\\:\\:startValueElement\\(\\) invoked with 3 parameters, 2 required\\.$#"
-			count: 1
-			path: src/contracts/Output/ValueObjectVisitor.php
 
 		-
 			message: "#^Method Ibexa\\\\Contracts\\\\Rest\\\\Output\\\\ValueObjectVisitor\\:\\:setRequestParser\\(\\) has no return type specified\\.$#"
@@ -906,16 +896,6 @@ parameters:
 			path: src/lib/Output/Generator/Json.php
 
 		-
-			message: "#^Method Ibexa\\\\Rest\\\\Output\\\\Generator\\\\Json\\:\\:startValueElement\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: src/lib/Output/Generator/Json.php
-
-		-
-			message: "#^Method Ibexa\\\\Rest\\\\Output\\\\Generator\\\\Json\\:\\:startValueElement\\(\\) has parameter \\$attributes with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: src/lib/Output/Generator/Json.php
-
-		-
 			message: "#^Parameter \\#1 \\$parent of method Ibexa\\\\Rest\\\\Output\\\\Generator\\\\Json\\\\FieldTypeHashGenerator\\:\\:generateHashValue\\(\\) expects Ibexa\\\\Rest\\\\Output\\\\Generator\\\\Json\\\\ArrayObject\\|Ibexa\\\\Rest\\\\Output\\\\Generator\\\\Json\\\\JsonObject, array given\\.$#"
 			count: 1
 			path: src/lib/Output/Generator/Json.php
@@ -1021,12 +1001,7 @@ parameters:
 			path: src/lib/Output/Generator/Xml.php
 
 		-
-			message: "#^Method Ibexa\\\\Rest\\\\Output\\\\Generator\\\\Xml\\:\\:startValueElement\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: src/lib/Output/Generator/Xml.php
-
-		-
-			message: "#^Method Ibexa\\\\Rest\\\\Output\\\\Generator\\\\Xml\\:\\:startValueElement\\(\\) has parameter \\$attributes with no value type specified in iterable type array\\.$#"
+			message: "#^Parameter \\#1 \\$content of method XMLWriter\\:\\:text\\(\\) expects string, bool\\|float\\|int\\|string\\|null given\\.$#"
 			count: 1
 			path: src/lib/Output/Generator/Xml.php
 
@@ -2936,11 +2911,6 @@ parameters:
 			path: src/lib/Server/Output/ValueObjectVisitor/BookmarkList.php
 
 		-
-			message: "#^Parameter \\#2 \\$value of method Ibexa\\\\Contracts\\\\Rest\\\\Output\\\\Generator\\:\\:startValueElement\\(\\) expects string, int given\\.$#"
-			count: 1
-			path: src/lib/Server/Output/ValueObjectVisitor/BookmarkList.php
-
-		-
 			message: "#^Method Ibexa\\\\Rest\\\\Server\\\\Output\\\\ValueObjectVisitor\\\\CachedValue\\:\\:getParameter\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: src/lib/Server/Output/ValueObjectVisitor/CachedValue.php
@@ -3311,11 +3281,6 @@ parameters:
 			path: src/lib/Server/Output/ValueObjectVisitor/ImageVariation.php
 
 		-
-			message: "#^Parameter \\#2 \\$value of method Ibexa\\\\Contracts\\\\Rest\\\\Output\\\\Generator\\:\\:startValueElement\\(\\) expects string, int\\<min, \\-1\\>\\|int\\<1, max\\> given\\.$#"
-			count: 3
-			path: src/lib/Server/Output/ValueObjectVisitor/ImageVariation.php
-
-		-
 			message: "#^Method Ibexa\\\\Rest\\\\Server\\\\Output\\\\ValueObjectVisitor\\\\Location\\:\\:visit\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: src/lib/Server/Output/ValueObjectVisitor/Location.php
@@ -3323,11 +3288,6 @@ parameters:
 		-
 			message: "#^Method Ibexa\\\\Rest\\\\Server\\\\Output\\\\ValueObjectVisitor\\\\Location\\:\\:visitLocationAttributes\\(\\) has no return type specified\\.$#"
 			count: 1
-			path: src/lib/Server/Output/ValueObjectVisitor/Location.php
-
-		-
-			message: "#^Parameter \\#2 \\$value of method Ibexa\\\\Contracts\\\\Rest\\\\Output\\\\Generator\\:\\:startValueElement\\(\\) expects string, int given\\.$#"
-			count: 4
 			path: src/lib/Server/Output/ValueObjectVisitor/Location.php
 
 		-
@@ -3491,21 +3451,6 @@ parameters:
 			path: src/lib/Server/Output/ValueObjectVisitor/RestExecutedView.php
 
 		-
-			message: "#^Parameter \\#2 \\$value of method Ibexa\\\\Contracts\\\\Rest\\\\Output\\\\Generator\\:\\:startValueElement\\(\\) expects string, float given\\.$#"
-			count: 1
-			path: src/lib/Server/Output/ValueObjectVisitor/RestExecutedView.php
-
-		-
-			message: "#^Parameter \\#2 \\$value of method Ibexa\\\\Contracts\\\\Rest\\\\Output\\\\Generator\\:\\:startValueElement\\(\\) expects string, int given\\.$#"
-			count: 1
-			path: src/lib/Server/Output/ValueObjectVisitor/RestExecutedView.php
-
-		-
-			message: "#^Parameter \\#2 \\$value of method Ibexa\\\\Contracts\\\\Rest\\\\Output\\\\Generator\\:\\:startValueElement\\(\\) expects string, int\\|null given\\.$#"
-			count: 1
-			path: src/lib/Server/Output/ValueObjectVisitor/RestExecutedView.php
-
-		-
 			message: "#^Parameter \\#5 \\$relations of class Ibexa\\\\Rest\\\\Server\\\\Values\\\\RestContent constructor expects array\\<Ibexa\\\\Contracts\\\\Core\\\\Repository\\\\Values\\\\Content\\\\Relation\\>\\|null, iterable\\<Ibexa\\\\Contracts\\\\Core\\\\Repository\\\\Values\\\\Content\\\\Relation\\> given\\.$#"
 			count: 1
 			path: src/lib/Server/Output/ValueObjectVisitor/RestExecutedView.php
@@ -3516,18 +3461,8 @@ parameters:
 			path: src/lib/Server/Output/ValueObjectVisitor/RestFieldDefinition.php
 
 		-
-			message: "#^Parameter \\#2 \\$value of method Ibexa\\\\Contracts\\\\Rest\\\\Output\\\\Generator\\:\\:startValueElement\\(\\) expects string, int given\\.$#"
-			count: 1
-			path: src/lib/Server/Output/ValueObjectVisitor/RestFieldDefinition.php
-
-		-
 			message: "#^Method Ibexa\\\\Rest\\\\Server\\\\Output\\\\ValueObjectVisitor\\\\RestLocation\\:\\:visit\\(\\) has no return type specified\\.$#"
 			count: 1
-			path: src/lib/Server/Output/ValueObjectVisitor/RestLocation.php
-
-		-
-			message: "#^Parameter \\#2 \\$value of method Ibexa\\\\Contracts\\\\Rest\\\\Output\\\\Generator\\:\\:startValueElement\\(\\) expects string, int given\\.$#"
-			count: 4
 			path: src/lib/Server/Output/ValueObjectVisitor/RestLocation.php
 
 		-
@@ -3541,11 +3476,6 @@ parameters:
 			path: src/lib/Server/Output/ValueObjectVisitor/RestObjectState.php
 
 		-
-			message: "#^Parameter \\#2 \\$value of method Ibexa\\\\Contracts\\\\Rest\\\\Output\\\\Generator\\:\\:startValueElement\\(\\) expects string, int given\\.$#"
-			count: 1
-			path: src/lib/Server/Output/ValueObjectVisitor/RestObjectState.php
-
-		-
 			message: "#^Method Ibexa\\\\Rest\\\\Server\\\\Output\\\\ValueObjectVisitor\\\\RestRelation\\:\\:visit\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: src/lib/Server/Output/ValueObjectVisitor/RestRelation.php
@@ -3553,11 +3483,6 @@ parameters:
 		-
 			message: "#^Method Ibexa\\\\Rest\\\\Server\\\\Output\\\\ValueObjectVisitor\\\\RestTrashItem\\:\\:visit\\(\\) has no return type specified\\.$#"
 			count: 1
-			path: src/lib/Server/Output/ValueObjectVisitor/RestTrashItem.php
-
-		-
-			message: "#^Parameter \\#2 \\$value of method Ibexa\\\\Contracts\\\\Rest\\\\Output\\\\Generator\\:\\:startValueElement\\(\\) expects string, int given\\.$#"
-			count: 4
 			path: src/lib/Server/Output/ValueObjectVisitor/RestTrashItem.php
 
 		-
@@ -3816,16 +3741,6 @@ parameters:
 			path: src/lib/Server/Output/ValueObjectVisitor/Version.php
 
 		-
-			message: "#^Parameter \\#2 \\$value of method Ibexa\\\\Contracts\\\\Rest\\\\Output\\\\Generator\\:\\:startValueElement\\(\\) expects string, int\\|null given\\.$#"
-			count: 2
-			path: src/lib/Server/Output/ValueObjectVisitor/Version.php
-
-		-
-			message: "#^Parameter \\#2 \\$value of method Ibexa\\\\Contracts\\\\Rest\\\\Output\\\\Generator\\:\\:startValueElement\\(\\) expects string, string\\|null given\\.$#"
-			count: 1
-			path: src/lib/Server/Output/ValueObjectVisitor/Version.php
-
-		-
 			message: "#^Access to an undefined property Ibexa\\\\Contracts\\\\Core\\\\Repository\\\\Values\\\\Content\\\\VersionInfo\\:\\:\\$names\\.$#"
 			count: 1
 			path: src/lib/Server/Output/ValueObjectVisitor/VersionInfo.php
@@ -3837,11 +3752,6 @@ parameters:
 
 		-
 			message: "#^Method Ibexa\\\\Rest\\\\Server\\\\Output\\\\ValueObjectVisitor\\\\VersionInfo\\:\\:visitVersionInfoAttributes\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: src/lib/Server/Output/ValueObjectVisitor/VersionInfo.php
-
-		-
-			message: "#^Parameter \\#2 \\$value of method Ibexa\\\\Contracts\\\\Rest\\\\Output\\\\Generator\\:\\:startValueElement\\(\\) expects string, int given\\.$#"
 			count: 1
 			path: src/lib/Server/Output/ValueObjectVisitor/VersionInfo.php
 
@@ -7596,11 +7506,6 @@ parameters:
 			path: tests/lib/Output/Generator/FieldTypeHashGeneratorBaseTest.php
 
 		-
-			message: "#^Method Ibexa\\\\Contracts\\\\Rest\\\\Output\\\\Generator\\:\\:startValueElement\\(\\) invoked with 3 parameters, 2 required\\.$#"
-			count: 1
-			path: tests/lib/Output/Generator/JsonTest.php
-
-		-
 			message: "#^Method Ibexa\\\\Tests\\\\Rest\\\\Output\\\\Generator\\\\JsonTest\\:\\:testGeneratorAttribute\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: tests/lib/Output/Generator/JsonTest.php
@@ -7689,11 +7594,6 @@ parameters:
 			message: "#^Property Ibexa\\\\Tests\\\\Rest\\\\Output\\\\Generator\\\\JsonTest\\:\\:\\$generator \\(Ibexa\\\\Contracts\\\\Rest\\\\Output\\\\Generator\\) in isset\\(\\) is not nullable\\.$#"
 			count: 1
 			path: tests/lib/Output/Generator/JsonTest.php
-
-		-
-			message: "#^Method Ibexa\\\\Contracts\\\\Rest\\\\Output\\\\Generator\\:\\:startValueElement\\(\\) invoked with 3 parameters, 2 required\\.$#"
-			count: 2
-			path: tests/lib/Output/Generator/XmlTest.php
 
 		-
 			message: "#^Method Ibexa\\\\Tests\\\\Rest\\\\Output\\\\Generator\\\\XmlTest\\:\\:testGeneratorAttribute\\(\\) has no return type specified\\.$#"


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | N/A
| **Type**| improvement
| **Target version** | `4.6
| **BC breaks**      | no
| **Tests pass**     | yes
| **Doc needed**     | no

This regenerates the PHPStan baseline for the current main branch, after merging 4.5 up.

**TODO**:
- [x] Implement tests.
- [x] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [x] Ask for Code Review.
