### PR TITLE
IBX-6640: Fixed infinite loop when Normalizer returns an object

### DIFF
--- a/src/lib/Output/Generator/Json/FieldTypeHashGenerator.php
+++ b/src/lib/Output/Generator/Json/FieldTypeHashGenerator.php
@@ -166,7 +166,11 @@ class FieldTypeHashGenerator implements LoggerAwareInterface
             $value = null;
         }
 
-        return $this->generateValue($parent, $value);
+        if (is_array($value)) {
+            return $this->generateArrayValue($parent, $value);
+        }
+
+        return $value;
     }
 }
 

--- a/src/lib/Output/Generator/Xml/FieldTypeHashGenerator.php
+++ b/src/lib/Output/Generator/Xml/FieldTypeHashGenerator.php
@@ -257,6 +257,8 @@ class FieldTypeHashGenerator implements LoggerAwareInterface
         }
 
         if (is_object($value)) {
+            $this->generateNullValue($writer, $key, $elementName);
+
             return;
         }
 

--- a/src/lib/Output/Generator/Xml/FieldTypeHashGenerator.php
+++ b/src/lib/Output/Generator/Xml/FieldTypeHashGenerator.php
@@ -255,6 +255,11 @@ class FieldTypeHashGenerator implements LoggerAwareInterface
             ]);
             $value = null;
         }
+
+        if (is_object($value)) {
+            return;
+        }
+
         $this->generateValue($writer, $value, $key, $elementName);
     }
 }

--- a/tests/lib/Output/Generator/FieldTypeHashGeneratorBaseTest.php
+++ b/tests/lib/Output/Generator/FieldTypeHashGeneratorBaseTest.php
@@ -219,6 +219,20 @@ abstract class FieldTypeHashGeneratorBaseTest extends TestCase
         $this->assertSerializationSame(__FUNCTION__);
     }
 
+    public function testGenerateObjectUsingNormalizer(): void
+    {
+        $object = (object)[];
+        $this->getNormalizer()
+            ->expects(self::once())
+            ->method('normalize')
+            ->with(self::identicalTo($object))
+            ->willReturnArgument(0);
+
+        $this->getGenerator()->generateFieldTypeHash('fieldValue', $object);
+
+        $this->assertSerializationSame(__FUNCTION__);
+    }
+
     public function testGenerateWithMissingNormalizer(): void
     {
         $object = (object)[];

--- a/tests/lib/Output/Generator/_fixtures/Json_FieldTypeHashGeneratorTest__testGenerateObjectUsingNormalizer.out
+++ b/tests/lib/Output/Generator/_fixtures/Json_FieldTypeHashGeneratorTest__testGenerateObjectUsingNormalizer.out
@@ -1,0 +1,1 @@
+{"Field":{"fieldValue":{}}}

--- a/tests/lib/Output/Generator/_fixtures/Xml_FieldTypeHashGeneratorTest__testGenerateObjectUsingNormalizer.out
+++ b/tests/lib/Output/Generator/_fixtures/Xml_FieldTypeHashGeneratorTest__testGenerateObjectUsingNormalizer.out
@@ -1,2 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<Field/>
+<Field>
+ <fieldValue/>
+</Field>

--- a/tests/lib/Output/Generator/_fixtures/Xml_FieldTypeHashGeneratorTest__testGenerateObjectUsingNormalizer.out
+++ b/tests/lib/Output/Generator/_fixtures/Xml_FieldTypeHashGeneratorTest__testGenerateObjectUsingNormalizer.out
@@ -1,0 +1,2 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Field/>


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [IBX-6640](https://issues.ibexa.co/browse/IBX-6640)
| **Type**| bug
| **Target version** | Ibexa `v4.5`
| **BC breaks**      | no
| **Tests pass**     | yes
| **Doc needed**     | no

When trying to fix an incorrect REST response shape, I have found out that the solution expected cannot work, because it relies on object being returned from Normalizer.
The incorrect response is (note the "data" property):
```json
{
    "ActivityLogList": {
        "_media-type": "application\/vnd.ibexa.api.ActivityLogList+json",
        "_href": "\/api\/ibexa\/v2\/activity_log\/view",
        "ActivityLog": [
            {
                "_media-type": "application\/vnd.ibexa.api.ActivityLog+json",
                "object_id": "test_object_id",
                "object_class": "stdClass",
                "action": "test_action",
                "user_id": 10,
                "logged_at": "__LOGGED_AT__",
                "data": []
            },
            {
                "_media-type": "application\/vnd.ibexa.api.ActivityLog+json",
                "object_id": "test_object_id",
                "object_class": "stdClass",
                "action": "test_action",
                "user_id": 10,
                "logged_at": "__LOGGED_AT__",
                "data": {
                    "foo": "bar"
                }
            }
        ]
    }
}
```
While the expected output would be:
```json
{
    "ActivityLogList": {
        "_media-type": "application\/vnd.ibexa.api.ActivityLogList+json",
        "_href": "\/api\/ibexa\/v2\/activity_log\/view",
        "ActivityLog": [
            {
                "_media-type": "application\/vnd.ibexa.api.ActivityLog+json",
                "object_id": "test_object_id",
                "object_class": "stdClass",
                "action": "test_action",
                "user_id": 10,
                "logged_at": "__LOGGED_AT__",
                "data": {}
            },
            {
                "_media-type": "application\/vnd.ibexa.api.ActivityLog+json",
                "object_id": "test_object_id",
                "object_class": "stdClass",
                "action": "test_action",
                "user_id": 10,
                "logged_at": "__LOGGED_AT__",
                "data": {
                    "foo": "bar"
                }
            }
        ]
    }
}
```
To fix this, `Ibexa\Rest\Output\Generator\Json\FieldTypeHashGenerator::generateObjectValue()` cannot call `Ibexa\Rest\Output\Generator\Json\FieldTypeHashGenerator::generateValue()`, because this results in an infinite loop.

When looking at `Ibexa\Rest\Output\Generator\Json\FieldTypeHashGenerator::generateValue()` you can notice that it works on 4 data types:
 * `null`
 * `scalar`
 * `array`
 * `object`
 
`null` and `scalar` work properly, and loop is broken immediately, so we can skip the additional call. 

`object` in current shape becomes an infinite loop. Those two methods keep calling each other.

`array` has the only special effect among all 4, where it performs a few list related tasks.

See

https://github.com/symfony/symfony/blob/0659364bbc51920ab6475186e40d1bf06a637047/src/Symfony/Component/Serializer/Serializer.php#L166-L173 

and

https://github.com/symfony/symfony/blob/0659364bbc51920ab6475186e40d1bf06a637047/src/Symfony/Component/Serializer/Serializer.php#L51-L55

 for explanation why objects sometimes are needed after normalization.

**TODO**:
- [x] Implement tests.
- [x] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [x] Ask for Code Review.
