### PR TITLE
Fixed PHPStan

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -4171,6 +4171,11 @@ parameters:
 			path: tests/bundle/DependencyInjection/Compiler/ValueObjectVisitorPassTest.php
 
 		-
+			message: "#^Call to an undefined method Symfony\\\\Component\\\\EventDispatcher\\\\EventDispatcherInterface\\:\\:expects\\(\\)\\.$#"
+			count: 1
+			path: tests/bundle/EventListener/CsrfListenerTest.php
+
+		-
 			message: "#^Method Ibexa\\\\Tests\\\\Bundle\\\\Rest\\\\EventListener\\\\CsrfListenerTest\\:\\:getCsrfProviderMock\\(\\) has invalid return type Symfony\\\\Component\\\\Form\\\\Extension\\\\Csrf\\\\CsrfProvider\\\\CsrfProviderInterface\\.$#"
 			count: 1
 			path: tests/bundle/EventListener/CsrfListenerTest.php


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | N/A
| **Type**| bug
| **Target version** | Ibexa `v4.5`

Fixes PHPStan by regenerating baseline.

Fixing the issue in question in tests causes subsequent errors to occur (steming from invalid annotations). To quickly address this issue for CI purposes I recommend adding it to baseline.

**TODO**:
- [x] Implement tests.
- [x] Fix new code according to Coding Standards (`$ composer fix-cs`).
- [x] Ask for Code Review.
