### PR TITLE
IBX-8119: Upgraded minimum PHP version to 8.3

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -12,17 +12,17 @@ jobs:
         name: Run code style check
         runs-on: "ubuntu-22.04"
         steps:
-            - uses: actions/checkout@v3
+            - uses: actions/checkout@v4
 
             - name: Setup PHP Action
               uses: shivammathur/setup-php@v2
               with:
-                  php-version: '8.1'
+                  php-version: '8.3'
                   coverage: none
                   extensions: 'pdo_sqlite, gd'
                   tools: cs2pr
 
-            - uses: ramsey/composer-install@v2
+            - uses: ramsey/composer-install@v3
               with:
                   dependency-versions: highest
 
@@ -38,12 +38,10 @@ jobs:
             fail-fast: false
             matrix:
                 php:
-                    - '7.4'
-                    - '8.0'
-                    - '8.2'
+                    - '8.3'
 
         steps:
-            - uses: actions/checkout@v3
+            - uses: actions/checkout@v4
 
             - name: Setup PHP Action
               uses: shivammathur/setup-php@v2
@@ -53,7 +51,7 @@ jobs:
                   extensions: pdo_sqlite, gd
                   tools: cs2pr
 
-            - uses: ramsey/composer-install@v2
+            - uses: ramsey/composer-install@v3
               with:
                   dependency-versions: highest
 

--- a/.github/workflows/integration-tests-callable.yaml
+++ b/.github/workflows/integration-tests-callable.yaml
@@ -16,7 +16,7 @@ jobs:
         timeout-minutes: 15
 
         steps:
-            - uses: actions/checkout@v2
+            - uses: actions/checkout@v4
 
             - name: Set project version
               run: |
@@ -33,7 +33,7 @@ jobs:
               uses: actions/cache@v2
               with:
                   path: ${{ env.COMPOSER_CACHE_DIR }}
-                  key: ${{ env.PROJECT_EDITION }}-${{ env.version }}-${{ github.sha }}
+                  key: "${{ env.PROJECT_EDITION }}-${{ env.version }}-${{ github.sha }}"
                   restore-keys: |
                     ${{ env.PROJECT_EDITION }}-${{ env.version }}
 

--- a/.github/workflows/integration-tests-callable.yaml
+++ b/.github/workflows/integration-tests-callable.yaml
@@ -26,7 +26,7 @@ jobs:
             - name: Setup PHP Action
               uses: shivammathur/setup-php@v2
               with:
-                  php-version: 7.4
+                  php-version: 8.3
                   coverage: none
 
             - name: Cache dependencies
@@ -38,6 +38,8 @@ jobs:
                     ${{ env.PROJECT_EDITION }}-${{ env.version }}
 
             - name: Set up whole project using the tested dependency
+              env:
+                  SETUP: ghcr.io/ibexa/docker/php:8.3-node18
               run: |
                 curl -L "https://raw.githubusercontent.com/ibexa/ci-scripts/main/bin/${{ env.version }}/prepare_project_edition.sh" > prepare_project_edition.sh
                 chmod +x prepare_project_edition.sh

--- a/.github/workflows/integration-tests-callable.yaml
+++ b/.github/workflows/integration-tests-callable.yaml
@@ -38,12 +38,10 @@ jobs:
                     ${{ env.PROJECT_EDITION }}-${{ env.version }}
 
             - name: Set up whole project using the tested dependency
-              env:
-                  SETUP: ghcr.io/ibexa/docker/php:8.3-node18
               run: |
                 curl -L "https://raw.githubusercontent.com/ibexa/ci-scripts/main/bin/${{ env.version }}/prepare_project_edition.sh" > prepare_project_edition.sh
                 chmod +x prepare_project_edition.sh
-                ./prepare_project_edition.sh ${{ env.PROJECT_EDITION }} ${{ env.version }} ${{ env.SETUP }}
+                ./prepare_project_edition.sh ${{ env.PROJECT_EDITION }} ${{ env.version }} ${{ env.SETUP }} ghcr.io/ibexa/docker/php:8.3-node18
 
             - name: Run setup command
               run: |

--- a/composer.json
+++ b/composer.json
@@ -24,50 +24,51 @@
         }
     },
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": " >=8.3",
         "ext-dom": "*",
         "ext-json": "*",
         "ext-libxml": "*",
         "ext-simplexml": "*",
         "ext-xmlwriter": "*",
-        "ibexa/core": "~5.0.0@dev",
-        "symfony/http-kernel": "^5.3",
-        "symfony/dependency-injection": "^5.3",
-        "symfony/routing": "^5.3",
-        "symfony/http-foundation": "^5.3",
+        "ibexa/core": "~5.0.x-dev",
+        "ibexa/templated-uri-bundle": "^3.2",
+        "lexik/jwt-authentication-bundle": "^2.8",
         "symfony/config": "^5.3",
-        "symfony/yaml": "^5.3",
+        "symfony/dependency-injection": "^5.3",
         "symfony/event-dispatcher": "^5.3",
-        "symfony/security-csrf": "^5.3",
         "symfony/expression-language": "^5.3",
         "symfony/form": "^5.3",
+        "symfony/http-foundation": "^5.3",
+        "symfony/http-kernel": "^5.3",
+        "symfony/routing": "^5.3",
         "symfony/security-bundle": "^5.3",
-        "ibexa/templated-uri-bundle": "^3.2",
-        "lexik/jwt-authentication-bundle": "^2.8"
+        "symfony/security-csrf": "^5.3",
+        "symfony/yaml": "^5.3"
     },
     "require-dev": {
-        "ibexa/ci-scripts": "^0.2@dev",
-        "ibexa/doctrine-schema": "~5.0.0@dev",
-        "ibexa/code-style": "^1.0",
-        "ibexa/test-core": "^0.1.x-dev",
         "friendsofphp/php-cs-fixer": "^3.0",
-        "phpunit/phpunit": "^8.5",
+        "ibexa/ci-scripts": "^0.2@dev",
+        "ibexa/code-style": "^1.0",
+        "ibexa/doctrine-schema": "~5.0.x-dev",
+        "ibexa/test-core": "^0.1.x-dev",
+        "justinrainbow/json-schema": "^5.2",
         "matthiasnoback/symfony-dependency-injection-test": "^4.1",
         "nyholm/psr7": "^1.1",
-        "symfony/http-client": "^5.3",
-        "symfony/browser-kit": "^5.3",
-        "justinrainbow/json-schema": "^5.2",
         "phpstan/phpstan": "^1.10",
-        "phpstan/phpstan-symfony": "^1.3",
         "phpstan/phpstan-phpunit": "^1.3",
-        "phpstan/phpstan-webmozart-assert": "^1.2"
+        "phpstan/phpstan-symfony": "^1.3",
+        "phpstan/phpstan-webmozart-assert": "^1.2",
+        "phpunit/phpunit": "^8.5",
+        "symfony/browser-kit": "^5.3",
+        "symfony/http-client": "^5.3"
     },
     "config": {
         "allow-plugins": {
             "composer/package-versions-deprecated": true,
             "*": false
         },
-        "process-timeout": 600
+        "process-timeout": 600,
+        "sort-packages": true
     },
     "scripts": {
         "fix-cs": "php-cs-fixer fix --config=.php-cs-fixer.php -v --show-progress=dots",


### PR DESCRIPTION
| :ticket: Issue | IBX-8119 |
|----------------|-----------|

#### Description:

This PR bumps the minimum required version of PHP to 8.3.
`>=8.3` version constraint is set with expectation of compatibility with version PHP 9.

Additionally, this PR:
 * enforces sorting of packages within `require` and `require-dev` sections of composer.json file
 * replaces `~5.0.0@dev` declarations with their more development friendly `~5.0.x-dev`.
 * adjusts github workflows to match new PHP version
 * updates GH action versions
