### PR TITLE
[PHPStan] Fixed parser list type hinting in ParserDispatcher

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -281,11 +281,6 @@ parameters:
 			path: src/contracts/Input/Handler.php
 
 		-
-			message: "#^Cannot access offset mixed on Ibexa\\\\Contracts\\\\Rest\\\\Input\\\\Parser\\.$#"
-			count: 1
-			path: src/contracts/Input/ParsingDispatcher.php
-
-		-
 			message: "#^Method Ibexa\\\\Contracts\\\\Rest\\\\Input\\\\ParsingDispatcher\\:\\:__construct\\(\\) has parameter \\$parsers with no value type specified in iterable type array\\.$#"
 			count: 1
 			path: src/contracts/Input/ParsingDispatcher.php
@@ -307,11 +302,6 @@ parameters:
 
 		-
 			message: "#^Method Ibexa\\\\Contracts\\\\Rest\\\\Input\\\\ParsingDispatcher\\:\\:parse\\(\\) has parameter \\$data with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: src/contracts/Input/ParsingDispatcher.php
-
-		-
-			message: "#^Method Ibexa\\\\Contracts\\\\Rest\\\\Input\\\\ParsingDispatcher\\:\\:parseMediaTypeVersion\\(\\) return type has no value type specified in iterable type array\\.$#"
 			count: 1
 			path: src/contracts/Input/ParsingDispatcher.php
 

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -10,5 +10,7 @@ parameters:
     paths:
         - src
         - tests
-    checkGenericClassInNonGenericObjectType: false
     treatPhpDocTypesAsCertain: false
+    ignoreErrors:
+        -
+            identifier: missingType.generics

--- a/src/contracts/Input/ParsingDispatcher.php
+++ b/src/contracts/Input/ParsingDispatcher.php
@@ -30,7 +30,7 @@ class ParsingDispatcher
      *  )
      * </code>
      *
-     * @var \Ibexa\Contracts\Rest\Input\Parser[]
+     * @var array<string, array<string, \Ibexa\Contracts\Rest\Input\Parser>>
      */
     protected array $parsers = [];
 
@@ -56,7 +56,7 @@ class ParsingDispatcher
      */
     public function addParser(string $mediaType, Parser $parser): void
     {
-        list($mediaType, $version) = $this->parseMediaTypeVersion($mediaType);
+        [$mediaType, $version] = $this->parseMediaTypeVersion($mediaType);
 
         $this->parsers[$mediaType][$version] = $parser;
     }
@@ -116,7 +116,7 @@ class ParsingDispatcher
      *
      * @param string $mediaType Ex: text/html; version=1.1
      *
-     * @return array An array with the media-type string, stripped from the version, and the version (1.0 by default)
+     * @return array{string, string} An array with the media-type string, stripped from the version, and the version (1.0 by default)
      */
     protected function parseMediaTypeVersion(string $mediaType): array
     {


### PR DESCRIPTION
| :ticket: Issue | n/a |
|----------------|-----------|

#### Description:

Fixed outstanding PHPStan-reported issues on 4.6:

- [x] [PHPDoc] Defined array shape for ParsingDispatcher::$parse member
- [x] [PHPDoc] Defined returned array shape of ParsingDispatcher::parseMediaTypeVersion method
- [x] [PHPStan] Aligned baseline with the changes
- [x] [PHPStan] Fixed deprecated checkGenericClassInNonGenericObjectType conf**