### PR TITLE
IBX-8290: Deprecated `ibexa.rest.refresh_session` route in favor of `ibexa.rest.check_session`

### DIFF
--- a/src/bundle/Resources/config/routing.yml
+++ b/src/bundle/Resources/config/routing.yml
@@ -595,7 +595,7 @@ ibexa.rest.load_content_type_field_definition:
     requirements:
         contentTypeId: \d+
         fieldDefinitionId: \d+
-        
+
 ibexa.rest.load_content_type_field_definition_by_identifier:
     path: /content/types/{contentTypeId}/fieldDefinition/{fieldDefinitionIdentifier}
     controller: Ibexa\Rest\Server\Controller\ContentType::loadContentTypeFieldDefinitionByIdentifier

--- a/src/lib/Server/Controller/SessionController.php
+++ b/src/lib/Server/Controller/SessionController.php
@@ -103,6 +103,8 @@ class SessionController extends Controller
     /**
      * Refresh given session.
      *
+     * @deprecated 4.6.7 The "SessionController::refreshSessionAction()" method is deprecated, will be removed in 5.0. Use SessionController::checkSessionAction() instead.
+     *
      * @param string $sessionId
      *
      * @throws \Ibexa\Contracts\Rest\Exceptions\NotFoundException
@@ -111,6 +113,12 @@ class SessionController extends Controller
      */
     public function refreshSessionAction($sessionId, Request $request)
     {
+        trigger_deprecation(
+            'ibexa/rest',
+            '4.6.7',
+            sprintf('The %s() method is deprecated, will be removed in 5.0.', __METHOD__)
+        );
+
         $session = $request->getSession();
 
         if ($session === null || !$session->isStarted() || $session->getId() != $sessionId || !$this->hasStoredCsrfToken()) {


### PR DESCRIPTION
| :ticket: Issue | IBX-8290 |
|----------------|-----------|

<!-- 
#### Related PRs: 
- https://github.com/ibexa/core/pull/1
-->

#### Description:
As part of re-implementing REST authorization compliant with the new Symfony authenticator mechanism I decided to deprecate `ibexa.rest.refresh_session` route as there is already `ibexa.rest.check_session` which does similar thing and has better usage. It will be removed as part of `5.0` targetting PR.

#### For QA:
<!-- Optional. Replace this comment with any necessary information needed by QA to test this Pull Request -->

#### Documentation:
Please mark this endpoint in REST API reference as deprecated and mention that `ibexa.rest.check_session` should be used instead.


<!-- 
Before you click submit:
    - Test the solution manually
    - Provide automated test coverage
    - Confirm that target branch is set correctly
    - Run PHP CS Fixer for new PHP code (use $ composer fix-cs)
    - Run ESLint and Prettier for new JS/SCSS code (use $ yarn fix)
    - Ask for a review (ping @ibexa/php-dev or @ibexa/javascript-dev depending on the changes) 
--> 
