### PR TITLE
IBX-8173: Implemented routing language expression parsing media type from `Content-Type` header

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -5516,11 +5516,6 @@ parameters:
 			path: tests/bundle/Routing/OptionsLoader/MapperTest.php
 
 		-
-			message: "#^Method Ibexa\\\\Tests\\\\Bundle\\\\Rest\\\\Routing\\\\OptionsLoader\\\\RouteCollectionMapperTest\\:\\:createRoute\\(\\) has parameter \\$methods with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: tests/bundle/Routing/OptionsLoader/RouteCollectionMapperTest.php
-
-		-
 			message: "#^Method Ibexa\\\\Tests\\\\Bundle\\\\Rest\\\\Routing\\\\OptionsLoader\\\\RouteCollectionMapperTest\\:\\:testAddRestRoutesCollection\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: tests/bundle/Routing/OptionsLoader/RouteCollectionMapperTest.php

--- a/src/bundle/Resources/config/routing.yml
+++ b/src/bundle/Resources/config/routing.yml
@@ -486,6 +486,16 @@ ibexa.rest.create_location:
 # Content types
 
 
+ibexa.rest.content_type.copy:
+    path: /content/types/{contentTypeId}
+    controller: Ibexa\Rest\Server\Controller\ContentType::copyContentType
+    condition: 'ibexa_get_media_type(request) === "CopyContentTypeInput"'
+    methods: [POST]
+    options:
+        options_route_suffix: 'CopyContentTypeInput'
+    requirements:
+        contentTypeId: \d+
+
 ibexa.rest.load_content_type_group_list:
     path: /content/typegroups
     defaults:

--- a/src/bundle/Resources/config/services.yml
+++ b/src/bundle/Resources/config/services.yml
@@ -390,3 +390,13 @@ services:
         parent: hautelook.router.template
         calls:
             - [ setOption, [ strict_requirements, ~ ] ]
+
+    Ibexa\Bundle\Rest\Routing\ExpressionLanguage\ContentTypeHeaderMatcherExpressionFunction:
+        arguments:
+            $mediaTypeParser: '@Ibexa\Contracts\Rest\Input\MediaTypeParserInterface'
+        tags:
+            - { name: routing.expression_language_function, function: 'ibexa_get_media_type' }
+
+    Ibexa\Contracts\Rest\Input\MediaTypeParser: ~
+
+    Ibexa\Contracts\Rest\Input\MediaTypeParserInterface: '@Ibexa\Contracts\Rest\Input\MediaTypeParser'

--- a/src/bundle/Routing/ExpressionLanguage/ContentTypeHeaderMatcherExpressionFunction.php
+++ b/src/bundle/Routing/ExpressionLanguage/ContentTypeHeaderMatcherExpressionFunction.php
@@ -1,0 +1,30 @@
+<?php
+
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace Ibexa\Bundle\Rest\Routing\ExpressionLanguage;
+
+use Ibexa\Contracts\Rest\Input\MediaTypeParserInterface;
+use Symfony\Component\HttpFoundation\Request;
+
+final readonly class ContentTypeHeaderMatcherExpressionFunction
+{
+    public function __construct(
+        private MediaTypeParserInterface $mediaTypeParser
+    ) {
+    }
+
+    public function __invoke(Request $request): ?string
+    {
+        $contentTypeHeaderValue = $request->headers->get('Content-Type');
+        if ($contentTypeHeaderValue === null) {
+            return null;
+        }
+
+        return $this->mediaTypeParser->parseContentTypeHeader($contentTypeHeaderValue);
+    }
+}

--- a/src/bundle/Routing/OptionsLoader/Mapper.php
+++ b/src/bundle/Routing/OptionsLoader/Mapper.php
@@ -65,15 +65,23 @@ class Mapper
 
     /**
      * Returns the OPTIONS name of a REST route.
-     *
-     * @param $route Route
-     *
-     * @return string
      */
-    public function getOptionsRouteName(Route $route)
+    public function getOptionsRouteName(Route $route): string
     {
         $name = str_replace('/', '_', $route->getPath());
 
-        return 'ibexa.rest.options.' . trim($name, '_');
+        $parts = [
+            'ibexa.rest.options',
+            trim($name, '_'),
+        ];
+
+        // Routes that share path 1-to-1 can result in overwrite.
+        // Use "options_route_suffix" to ensure uniqueness.
+        $routeSuffix = $route->getOption('options_route_suffix');
+        if ($routeSuffix !== null) {
+            $parts[] = $routeSuffix;
+        }
+
+        return implode('.', $parts);
     }
 }

--- a/src/contracts/Input/MediaTypeParser.php
+++ b/src/contracts/Input/MediaTypeParser.php
@@ -1,0 +1,23 @@
+<?php
+
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace Ibexa\Contracts\Rest\Input;
+
+final class MediaTypeParser implements MediaTypeParserInterface
+{
+    private const string MEDIA_TYPE_PATTERN = '/application\/vnd\.ibexa\.api\.([^.]+)\+/';
+
+    public function parseContentTypeHeader(string $header): ?string
+    {
+        if (preg_match(self::MEDIA_TYPE_PATTERN, $header, $matches)) {
+            return $matches[1];
+        }
+
+        return null;
+    }
+}

--- a/src/contracts/Input/MediaTypeParserInterface.php
+++ b/src/contracts/Input/MediaTypeParserInterface.php
@@ -1,0 +1,14 @@
+<?php
+
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace Ibexa\Contracts\Rest\Input;
+
+interface MediaTypeParserInterface
+{
+    public function parseContentTypeHeader(string $header): ?string;
+}

--- a/tests/bundle/Functional/HttpOptionsTest.php
+++ b/tests/bundle/Functional/HttpOptionsTest.php
@@ -84,6 +84,7 @@ class HttpOptionsTest extends TestCase
             ['/content/typegroups/1', ['GET', 'PATCH', 'DELETE']],
             ['/content/typegroups/1/types', ['GET', 'POST']],
             ['/content/types', ['GET']],
+            ['/content/types/1', ['POST'], 'CopyContentTypeInput+json'],
             ['/content/types/1', ['COPY', 'GET', 'POST', 'DELETE']],
             ['/content/types/1/draft', ['DELETE', 'GET', 'PATCH', 'PUBLISH']],
             ['/content/types/1/fieldDefinitions', ['GET']],

--- a/tests/bundle/Functional/HttpOptionsTest.php
+++ b/tests/bundle/Functional/HttpOptionsTest.php
@@ -18,15 +18,21 @@ class HttpOptionsTest extends TestCase
      *
      * @dataProvider providerForTestHttpOptions
      *
-     * @param string $route
-     * @param string[] $expectedMethods
+     * @param array<string> $expectedMethods
      */
-    public function testHttpOptions(string $route, array $expectedMethods): void
-    {
+    public function testHttpOptions(
+        string $route,
+        array $expectedMethods,
+        ?string $contentType = null
+    ): void {
         $restAPIPrefix = '/api/ibexa/v2';
 
         $response = $this->sendHttpRequest(
-            $this->createHttpRequest('OPTIONS', "{$restAPIPrefix}{$route}")
+            $this->createHttpRequest(
+                'OPTIONS',
+                "{$restAPIPrefix}{$route}",
+                $contentType ?? '',
+            )
         );
 
         self::assertHttpResponseCodeEquals($response, 200);

--- a/tests/bundle/Routing/ExpressionLanguage/ContentTypeHeaderMatcherExpressionFunctionTest.php
+++ b/tests/bundle/Routing/ExpressionLanguage/ContentTypeHeaderMatcherExpressionFunctionTest.php
@@ -1,0 +1,51 @@
+<?php
+
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace Ibexa\Tests\Bundle\Rest\Routing\ExpressionLanguage;
+
+use Ibexa\Bundle\Rest\Routing\ExpressionLanguage\ContentTypeHeaderMatcherExpressionFunction;
+use Ibexa\Contracts\Rest\Input\MediaTypeParser;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpFoundation\Request;
+
+final class ContentTypeHeaderMatcherExpressionFunctionTest extends TestCase
+{
+    private readonly ContentTypeHeaderMatcherExpressionFunction $contentTypeHeaderMatcher;
+
+    protected function setUp(): void
+    {
+        $contentTypeHeaderMatcher = new ContentTypeHeaderMatcherExpressionFunction(
+            new MediaTypeParser(),
+        );
+        $this->contentTypeHeaderMatcher = $contentTypeHeaderMatcher;
+    }
+
+    public function testGetMediaType(): void
+    {
+        $request = new Request();
+        $request->headers->add([
+            'Content-Type' => 'application/vnd.ibexa.api.CopyContentTypeInput+json',
+        ]);
+
+        $closure = $this->contentTypeHeaderMatcher;
+
+        self::assertSame('CopyContentTypeInput', $closure($request));
+    }
+
+    public function testRequestContentTypeDoesNotMatchRoute(): void
+    {
+        $request = new Request();
+        $request->headers->add([
+            'Content-Type' => 'application.CreateContentTypeInput+xml',
+        ]);
+
+        $closure = $this->contentTypeHeaderMatcher;
+
+        self::assertNull($closure($request));
+    }
+}

--- a/tests/bundle/Routing/OptionsLoader/RouteCollectionMapperTest.php
+++ b/tests/bundle/Routing/OptionsLoader/RouteCollectionMapperTest.php
@@ -63,14 +63,40 @@ class RouteCollectionMapperTest extends TestCase
         );
     }
 
-    /**
-     * @param string $path
-     * @param array $methods
-     *
-     * @return \Symfony\Component\Routing\Route
-     */
-    private function createRoute($path, array $methods)
+    public function testAddRestRoutesCollectionWithConditionAndSuffix(): void
     {
-        return new Route($path, [], [], [], '', [], $methods);
+        $restRoutesCollection = new RouteCollection();
+        $restRoutesCollection->add(
+            'ibexa.rest.route_three_post',
+            $this->createRoute(
+                '/route/three',
+                ['POST'],
+                'ibexa_get_media_type(request) === "RouteThreeInput"',
+                ['options_route_suffix' => 'RouteThreeInput'],
+            ),
+        );
+
+        $optionsRouteCollection = $this->collectionMapper->mapCollection($restRoutesCollection);
+
+        self::assertCount(1, $optionsRouteCollection);
+
+        $optionsRoute = $optionsRouteCollection->get('ibexa.rest.options.route_three.RouteThreeInput');
+
+        self::assertInstanceOf(Route::class, $optionsRoute);
+
+        self::assertEquals('POST', $optionsRoute->getDefault('allowedMethods'));
+    }
+
+    /**
+     * @param array<string> $methods
+     * @param array<string> $options
+     */
+    private function createRoute(
+        string $path,
+        array $methods,
+        ?string $condition = null,
+        array $options = [],
+    ): Route {
+        return new Route($path, [], [], $options, '', [], $methods, $condition);
     }
 }

--- a/tests/lib/Input/MediaTypeParserTest.php
+++ b/tests/lib/Input/MediaTypeParserTest.php
@@ -1,0 +1,49 @@
+<?php
+
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace Ibexa\Tests\Rest\Input;
+
+use Ibexa\Contracts\Rest\Input\MediaTypeParser;
+use Ibexa\Contracts\Rest\Input\MediaTypeParserInterface;
+use PHPUnit\Framework\TestCase;
+
+final class MediaTypeParserTest extends TestCase
+{
+    private readonly MediaTypeParserInterface $mediaTypeParser;
+
+    protected function setUp(): void
+    {
+        $this->mediaTypeParser = new MediaTypeParser();
+    }
+
+    public function testParsingSuccesses(): void
+    {
+        $header = 'application/vnd.ibexa.api.CopyContentTypeInput+json';
+
+        self::assertSame('CopyContentTypeInput', $this->mediaTypeParser->parseContentTypeHeader($header));
+    }
+
+    /**
+     * @dataProvider providerForParsingFails
+     */
+    public function testParsingFails(string $header): void
+    {
+        self::assertNull($this->mediaTypeParser->parseContentTypeHeader($header));
+    }
+
+    /**
+     * @return iterable<array<int, string>>
+     */
+    public function providerForParsingFails(): iterable
+    {
+        yield 'a' => ['application.CopyContentTypeInput+json'];
+        yield 'b' => ['application.CopyContentTypeInput'];
+        yield 'c' => ['CopyContentTypeInput+json'];
+        yield 'd' => ['CopyContentTypeInput'];
+    }
+}


### PR DESCRIPTION
| :ticket: Issue | IBX-8173|
|----------------|-----------|

#### Description:
As agreed internally to avoid methods' duplication a new routing expression language function was implemented that allows parsing media type value from the `Content-Type` header.

Usage:
```yaml
condition: 'ibexa_get_media_type(request) === "CopyContentTypeInput"'
```

Additionally, it was used to make copy content type endpoint OpenAPI compatible.
```
POST /api/v2/ibexa/content/types/1
Content-Type: application/vnd.ibexa.api.CopyContentTypeInput+json
Accept: application/json
{
    "CopyContentTypeInput": {}
}
```

<!-- 
Before you click submit:
    - Test the solution manually
    - Provide automated test coverage
    - Confirm that target branch is set correctly
    - Run PHP CS Fixer for new PHP code (use $ composer fix-cs)
    - Run ESLint and Prettier for new JS/SCSS code (use $ yarn fix)
    - Ask for a review (ping @ibexa/php-dev or @ibexa/javascript-dev depending on the changes) 
--> 
