### PR TITLE
IBX-8368: Implement dedicated location trashing endpoint

### DIFF
--- a/src/bundle/Resources/config/routing.yml
+++ b/src/bundle/Resources/config/routing.yml
@@ -775,6 +775,16 @@ ibexa.rest.unlink_content_type_from_group:
 # Trash
 
 
+ibexa.rest.trash_location:
+    path: /content/locations/{locationPath}
+    controller: Ibexa\Rest\Server\Controller\Trash::trashLocation
+    condition: 'ibexa_get_media_type(request) === "TrashLocationInput"'
+    methods: [POST]
+    options:
+        options_route_suffix: 'TrashLocationInput'
+    requirements:
+        locationPath: "[0-9/]+"
+
 ibexa.rest.trash.restore_trash_item:
     path: /content/trash/{trashItemId}
     controller: Ibexa\Rest\Server\Controller\Trash::restoreItem

--- a/src/bundle/Resources/config/routing.yml
+++ b/src/bundle/Resources/config/routing.yml
@@ -432,6 +432,16 @@ ibexa.rest.languages.view:
 
 # Locations
 
+ibexa.rest.trash_location:
+    path: /content/locations/{locationPath}
+    controller: Ibexa\Rest\Server\Controller\Trash::trashLocation
+    condition: 'ibexa_get_media_type(request) === "TrashLocationInput"'
+    methods: [POST]
+    options:
+        options_route_suffix: 'TrashLocationInput'
+    requirements:
+        locationPath: "[0-9/]+"
+
 ibexa.rest.location.swap:
     path: /content/locations/{locationPath}
     controller: Ibexa\Rest\Server\Controller\Location::swap
@@ -774,16 +784,6 @@ ibexa.rest.unlink_content_type_from_group:
 
 # Trash
 
-
-ibexa.rest.trash_location:
-    path: /content/locations/{locationPath}
-    controller: Ibexa\Rest\Server\Controller\Trash::trashLocation
-    condition: 'ibexa_get_media_type(request) === "TrashLocationInput"'
-    methods: [POST]
-    options:
-        options_route_suffix: 'TrashLocationInput'
-    requirements:
-        locationPath: "[0-9/]+"
 
 ibexa.rest.trash.restore_trash_item:
     path: /content/trash/{trashItemId}

--- a/src/bundle/Resources/config/routing.yml
+++ b/src/bundle/Resources/config/routing.yml
@@ -436,7 +436,7 @@ ibexa.rest.trash_location:
     path: /content/locations/{locationPath}
     controller: Ibexa\Rest\Server\Controller\Trash::trashLocation
     condition: 'ibexa_get_media_type(request) === "TrashLocationInput"'
-    methods: [POST]
+    methods: [POST, TRASH]
     options:
         options_route_suffix: 'TrashLocationInput'
     requirements:

--- a/tests/bundle/Functional/HttpOptionsTest.php
+++ b/tests/bundle/Functional/HttpOptionsTest.php
@@ -83,7 +83,7 @@ class HttpOptionsTest extends TestCase
             ['/content/locations/1/2', ['POST'], 'MoveLocationInput+json'],
             ['/content/locations/1/2', ['POST'], 'SwapLocationInput+json'],
             ['/content/locations/1/2', ['GET', 'PATCH', 'DELETE', 'COPY', 'MOVE', 'SWAP']],
-            ['/content/locations/1/2', ['POST'], 'TrashLocationInput+json'],
+            ['/content/locations/1/2', ['POST', 'TRASH'], 'TrashLocationInput+json'],
             ['/content/locations/1/2/children', ['GET']],
             ['/content/objects/1/locations', ['GET', 'POST']],
             ['/content/typegroups', ['GET', 'POST']],

--- a/tests/bundle/Functional/HttpOptionsTest.php
+++ b/tests/bundle/Functional/HttpOptionsTest.php
@@ -83,6 +83,7 @@ class HttpOptionsTest extends TestCase
             ['/content/locations/1/2', ['POST'], 'MoveLocationInput+json'],
             ['/content/locations/1/2', ['POST'], 'SwapLocationInput+json'],
             ['/content/locations/1/2', ['GET', 'PATCH', 'DELETE', 'COPY', 'MOVE', 'SWAP']],
+            ['/content/locations/1/2', ['POST'], 'TrashLocationInput+json'],
             ['/content/locations/1/2/children', ['GET']],
             ['/content/objects/1/locations', ['GET', 'POST']],
             ['/content/typegroups', ['GET', 'POST']],

--- a/tests/bundle/Functional/TrashTest.php
+++ b/tests/bundle/Functional/TrashTest.php
@@ -152,6 +152,19 @@ class TrashTest extends RESTFunctionalTestCase
         self::assertHttpResponseHasHeader($response, 'Location');
     }
 
+    public function testTrashLocationInvalidLocation(): void
+    {
+        $request = $this->createHttpRequest(
+            'POST',
+            '/api/ibexa/v2/content/locations/a/b/c',
+            'TrashLocationInput+json',
+        );
+
+        $response = $this->sendHttpRequest($request);
+
+        self::assertHttpResponseCodeEquals($response, 404);
+    }
+
     /**
      * Creates a folder, and sends it to trash.
      *

--- a/tests/bundle/Functional/TrashTest.php
+++ b/tests/bundle/Functional/TrashTest.php
@@ -133,6 +133,25 @@ class TrashTest extends RESTFunctionalTestCase
         self::assertHttpResponseCodeEquals($response, 404);
     }
 
+    public function testTrashLocation(): void
+    {
+        $folder = $this->createFolder('folderToTrash', '/api/ibexa/v2/content/locations/1/2');
+
+        $folderLocations = $this->getContentLocations($folder['_href']);
+        $locationHref = $folderLocations['LocationList']['Location'][0]['_href'];
+
+        $request = $this->createHttpRequest(
+            'POST',
+            $locationHref,
+            'TrashLocationInput+json',
+        );
+
+        $response = $this->sendHttpRequest($request);
+
+        self::assertHttpResponseCodeEquals($response, 201);
+        self::assertHttpResponseHasHeader($response, 'Location');
+    }
+
     /**
      * Creates a folder, and sends it to trash.
      *


### PR DESCRIPTION
| :ticket: Issue | IBX-8368 |
|----------------|-----------|


#### Related PRs: 
https://github.com/ibexa/rest/pull/100

#### Description:
The new endpoint follows the given specification:
```
POST|TRASH /api/ibexa/v2/content/locations/1/2/71
Content-Type: application/vnd.ibexa.api.TrashLocationInput+json
Accept: application/json
{
    "TrashLocationInput": {}
}
```

#### Documentation:
TBD
