### PR TITLE
IBX-8597: Added BaseSortClauseProcessor

### DIFF
--- a/src/bundle/Resources/config/services.yml
+++ b/src/bundle/Resources/config/services.yml
@@ -395,3 +395,8 @@ services:
         abstract: true
         arguments:
             $parsingDispatcher: '@Ibexa\Contracts\Rest\Input\ParsingDispatcher'
+
+    Ibexa\Contracts\Rest\Input\Parser\Query\SortClause\BaseSortClauseProcessor:
+        abstract: true
+        arguments:
+            $parsingDispatcher: '@Ibexa\Contracts\Rest\Input\ParsingDispatcher'

--- a/src/contracts/Input/Parser/Query/SortClause/BaseSortClauseProcessor.php
+++ b/src/contracts/Input/Parser/Query/SortClause/BaseSortClauseProcessor.php
@@ -23,7 +23,7 @@ abstract class BaseSortClauseProcessor implements SortClauseProcessorInterface
         $this->parsingDispatcher = $parsingDispatcher;
     }
 
-    public function processSortClauses(array $sortClauseData): iterable
+    final public function processSortClauses(array $sortClauseData): iterable
     {
         if (empty($sortClauseData)) {
             yield from [];

--- a/src/contracts/Input/Parser/Query/SortClause/BaseSortClauseProcessor.php
+++ b/src/contracts/Input/Parser/Query/SortClause/BaseSortClauseProcessor.php
@@ -1,0 +1,57 @@
+<?php
+
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace Ibexa\Contracts\Rest\Input\Parser\Query\SortClause;
+
+use Ibexa\Contracts\Rest\Exceptions;
+use Ibexa\Contracts\Rest\Input\ParsingDispatcher;
+use Traversable;
+
+/**
+ * @template TSortClause
+ *
+ * @internal
+ */
+abstract class BaseSortClauseProcessor implements SortClauseProcessorInterface
+{
+    private ParsingDispatcher $parsingDispatcher;
+
+    public function __construct(ParsingDispatcher $parsingDispatcher)
+    {
+        $this->parsingDispatcher = $parsingDispatcher;
+    }
+
+    public function processSortClauses(array $sortClauseData): Traversable
+    {
+        if (empty($sortClauseData)) {
+            yield from [];
+        }
+
+        foreach ($sortClauseData as $sortClauseName => $direction) {
+            $mediaType = $this->getSortClauseMediaType($sortClauseName);
+
+            try {
+                yield $this->parsingDispatcher->parse([$sortClauseName => $direction], $mediaType);
+            } catch (Exceptions\Parser $e) {
+                throw new Exceptions\Parser($this->getParserInvalidSortClauseMessage($sortClauseName), 0, $e);
+            }
+        }
+    }
+
+    abstract protected function getMediaTypePrefix(): string;
+
+    abstract protected function getParserInvalidSortClauseMessage(string $sortClauseName): string;
+    
+    private function getSortClauseMediaType(string $sortClauseName): string
+    {
+        $mediaTypePrefix = $this->getMediaTypePrefix();
+        if ('.' !== substr($mediaTypePrefix, strlen($mediaTypePrefix) - 1)) {
+            $mediaTypePrefix .= '.';
+        }
+
+        return $mediaTypePrefix . $sortClauseName;
+    }
+}

--- a/src/contracts/Input/Parser/Query/SortClause/BaseSortClauseProcessor.php
+++ b/src/contracts/Input/Parser/Query/SortClause/BaseSortClauseProcessor.php
@@ -8,7 +8,6 @@ namespace Ibexa\Contracts\Rest\Input\Parser\Query\SortClause;
 
 use Ibexa\Contracts\Rest\Exceptions;
 use Ibexa\Contracts\Rest\Input\ParsingDispatcher;
-use Traversable;
 
 /**
  * @template TSortClause
@@ -24,7 +23,7 @@ abstract class BaseSortClauseProcessor implements SortClauseProcessorInterface
         $this->parsingDispatcher = $parsingDispatcher;
     }
 
-    public function processSortClauses(array $sortClauseData): Traversable
+    public function processSortClauses(array $sortClauseData): iterable
     {
         if (empty($sortClauseData)) {
             yield from [];

--- a/src/contracts/Input/Parser/Query/SortClause/BaseSortClauseProcessor.php
+++ b/src/contracts/Input/Parser/Query/SortClause/BaseSortClauseProcessor.php
@@ -4,6 +4,8 @@
  * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+declare(strict_types=1);
+
 namespace Ibexa\Contracts\Rest\Input\Parser\Query\SortClause;
 
 use Ibexa\Contracts\Rest\Exceptions;
@@ -43,7 +45,7 @@ abstract class BaseSortClauseProcessor implements SortClauseProcessorInterface
     abstract protected function getMediaTypePrefix(): string;
 
     abstract protected function getParserInvalidSortClauseMessage(string $sortClauseName): string;
-    
+
     private function getSortClauseMediaType(string $sortClauseName): string
     {
         $mediaTypePrefix = $this->getMediaTypePrefix();

--- a/src/contracts/Input/Parser/Query/SortClause/SortClauseProcessorInterface.php
+++ b/src/contracts/Input/Parser/Query/SortClause/SortClauseProcessorInterface.php
@@ -1,0 +1,24 @@
+<?php
+
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace Ibexa\Contracts\Rest\Input\Parser\Query\SortClause;
+
+use Traversable;
+
+/**
+ * @template TSortClause
+ *
+ * @internal
+ */
+interface SortClauseProcessorInterface
+{
+    /**
+     * @param array<string, string> $sortClauseData
+     *
+     * @return \Traversable<TSortClause>
+     */
+    public function processSortClauses(array $sortClauseData): Traversable;
+}

--- a/src/contracts/Input/Parser/Query/SortClause/SortClauseProcessorInterface.php
+++ b/src/contracts/Input/Parser/Query/SortClause/SortClauseProcessorInterface.php
@@ -4,6 +4,8 @@
  * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+declare(strict_types=1);
+
 namespace Ibexa\Contracts\Rest\Input\Parser\Query\SortClause;
 
 /**

--- a/src/contracts/Input/Parser/Query/SortClause/SortClauseProcessorInterface.php
+++ b/src/contracts/Input/Parser/Query/SortClause/SortClauseProcessorInterface.php
@@ -6,8 +6,6 @@
  */
 namespace Ibexa\Contracts\Rest\Input\Parser\Query\SortClause;
 
-use Traversable;
-
 /**
  * @template TSortClause
  *
@@ -18,7 +16,7 @@ interface SortClauseProcessorInterface
     /**
      * @param array<string, string> $sortClauseData
      *
-     * @return \Traversable<TSortClause>
+     * @return iterable<TSortClause>
      */
-    public function processSortClauses(array $sortClauseData): Traversable;
+    public function processSortClauses(array $sortClauseData): iterable;
 }


### PR DESCRIPTION
| :ticket: Issue | [IBX-8597](https://issues.ibexa.co/browse/IBX-8597) |
|----------------|-----------|

#### Related PRs: 
- https://github.com/ibexa/shipping/pull/77
- https://github.com/ibexa/product-catalog/pull/1171

#### Description:
This PR adds `BaseSortClauseProcessor` to avoid duplicating code in several packages like:

- https://github.com/ibexa/shipping/blob/main/src/lib/REST/Input/Query/SortClause/Shipment/SortClauseProcessor.php
- https://github.com/ibexa/product-catalog/blob/main/src/bundle/REST/Input/Parser/Query/Criterion/CriterionProcessor.php#L52

BaseSortClauseProcessor is used to parse sort clauses.

#### For QA:
<!-- Optional. Replace this comment with any necessary information needed by QA to test this Pull Request -->

#### Documentation:
<!-- Optional. Replace this comment with details helpful for writing the doc: overview, code snippets for extensibility etc. -->


<!-- 
Before you click submit:
    - Test the solution manually
    - Provide automated test coverage
    - Confirm that target branch is set correctly
    - Run PHP CS Fixer for new PHP code (use $ composer fix-cs)
    - Run ESLint and Prettier for new JS/SCSS code (use $ yarn fix)
    - Ask for a review (ping @ibexa/php-dev or @ibexa/javascript-dev depending on the changes) 
--> 
