### PR TITLE
IBX-8174: Fixed restore trash item response codes to match the spec

### DIFF
--- a/src/lib/Server/Controller/Trash.php
+++ b/src/lib/Server/Controller/Trash.php
@@ -198,7 +198,7 @@ class Trash extends RestController
             try {
                 $locationDestination = $this->locationService->loadLocation($trashItem->parentLocationId);
             } catch (NotFoundException $e) {
-                throw new ForbiddenException(/** @Ignore */ $e->getMessage());
+                throw new ForbiddenException(/** @Ignore */ $e->getMessage(), 1, $e);
             }
         }
 

--- a/src/lib/Server/Controller/Trash.php
+++ b/src/lib/Server/Controller/Trash.php
@@ -7,6 +7,7 @@
 
 namespace Ibexa\Rest\Server\Controller;
 
+use Ibexa\Contracts\Core\Repository\Exceptions as ApiExceptions;
 use Ibexa\Contracts\Core\Repository\Exceptions\NotFoundException;
 use Ibexa\Contracts\Core\Repository\LocationService;
 use Ibexa\Contracts\Core\Repository\TrashService;
@@ -185,12 +186,17 @@ class Trash extends RestController
      */
     public function restoreItem(int $trashItemId, Request $request): Values\ResourceCreated
     {
-        $locationDestination = $this->inputDispatcher->parse(
-            new Message(
-                ['Content-Type' => $request->headers->get('Content-Type')],
-                $request->getContent(),
-            ),
-        );
+        try {
+            /** @var \Ibexa\Contracts\Core\Repository\Values\Content\Location|null $locationDestination */
+            $locationDestination = $this->inputDispatcher->parse(
+                new Message(
+                    ['Content-Type' => $request->headers->get('Content-Type')],
+                    $request->getContent(),
+                ),
+            );
+        } catch (ApiExceptions\NotFoundException $e) {
+            throw new ForbiddenException(/** @Ignore */ $e->getMessage(), 1, $e);
+        }
 
         $trashItem = $this->trashService->loadTrashItem($trashItemId);
 

--- a/src/lib/Server/Controller/Trash.php
+++ b/src/lib/Server/Controller/Trash.php
@@ -127,9 +127,9 @@ class Trash extends RestController
      *
      * @param $trashItemId
      *
-     * @throws \Ibexa\Rest\Server\Exceptions\ForbiddenException
-     *
      * @return \Ibexa\Rest\Server\Values\ResourceCreated
+     *
+     * @throws \Ibexa\Rest\Server\Exceptions\ForbiddenException
      */
     public function restoreTrashItem($trashItemId, Request $request)
     {
@@ -194,7 +194,11 @@ class Trash extends RestController
         $trashItem = $this->trashService->loadTrashItem($trashItemId);
 
         if ($locationDestination === null) {
-            $locationDestination = $this->locationService->loadLocation($trashItem->parentLocationId);
+            try {
+                $locationDestination = $this->locationService->loadLocation($trashItem->parentLocationId);
+            } catch (NotFoundException $e) {
+                throw new ForbiddenException(/** @Ignore */ $e->getMessage());
+            }
         }
 
         $location = $this->trashService->recover($trashItem, $locationDestination);

--- a/src/lib/Server/Controller/Trash.php
+++ b/src/lib/Server/Controller/Trash.php
@@ -181,6 +181,7 @@ class Trash extends RestController
     /**
      * @throws \Ibexa\Contracts\Core\Repository\Exceptions\NotFoundException
      * @throws \Ibexa\Contracts\Core\Repository\Exceptions\UnauthorizedException
+     * @throws \Ibexa\Contracts\Core\Repository\Exceptions\ForbiddenException
      */
     public function restoreItem(int $trashItemId, Request $request): Values\ResourceCreated
     {

--- a/tests/bundle/Functional/TrashTest.php
+++ b/tests/bundle/Functional/TrashTest.php
@@ -230,4 +230,20 @@ class TrashTest extends RESTFunctionalTestCase
 
         self::assertHttpResponseCodeEquals($response, 403);
     }
+
+    public function testRestoreTrashItemToMissingLocationThrowsForbiddenException(): void
+    {
+        $trashItemHref = $this->createTrashItem('testItemToRestore');
+
+        $request = $this->createHttpRequest(
+            'POST',
+            $trashItemHref,
+            'RestoreTrashItemInput+json',
+            '',
+            json_encode(['RestoreTrashItemInput' => ['destination' => '/1/22222']], JSON_THROW_ON_ERROR),
+        );
+        $response = $this->sendHttpRequest($request);
+
+        self::assertHttpResponseCodeEquals($response, 403);
+    }
 }

--- a/tests/bundle/Functional/TrashTest.php
+++ b/tests/bundle/Functional/TrashTest.php
@@ -203,4 +203,31 @@ class TrashTest extends RESTFunctionalTestCase
         self::assertHttpResponseCodeEquals($response, 201);
         self::assertHttpResponseHasHeader($response, 'Location');
     }
+
+    public function testRestoreTrashItemWithMissingOriginalLocationThrowsException(): void
+    {
+        $containerFolder = $this->createFolder('container', '/api/ibexa/v2/content/locations/1/2');
+        $containerFolderLocations = $this->getContentLocations($containerFolder['_href']);
+        $containerFolderLocationHref = $containerFolderLocations['LocationList']['Location'][0]['_href'];
+
+        $folder = $this->createFolder('toRemove', $containerFolderLocationHref);
+        $folderLocations = $this->getContentLocations($folder['_href']);
+
+        // Send folder to trash
+        $trashItemHref = $this->sendLocationToTrash($folderLocations['LocationList']['Location'][0]['_href']);
+
+        // Send container folder to trash
+        $this->sendLocationToTrash($containerFolderLocationHref);
+
+        $request = $this->createHttpRequest(
+            'POST',
+            $trashItemHref,
+            'RestoreTrashItemInput+json',
+            '',
+            json_encode(['RestoreTrashItemInput' => []], JSON_THROW_ON_ERROR),
+        );
+        $response = $this->sendHttpRequest($request);
+
+        self::assertHttpResponseCodeEquals($response, 403);
+    }
 }


### PR DESCRIPTION
| :ticket: Issue | IBX-8174 |
|----------------|-----------|

#### Description:
Please see https://doc.ibexa.co/en/4.6/api/rest_api/rest_api_reference/rest_api_reference.html#managing-content-untrash-content-item. The only difference is that the endpoint will throw 403 if original location doesn't exist.

#### For QA:
Trash content and its parent and then try to restore trash item without using the `destination` parameter.

#### Documentation:
TBD

<!-- 
Before you click submit:
    - Test the solution manually
    - Provide automated test coverage
    - Confirm that target branch is set correctly
    - Run PHP CS Fixer for new PHP code (use $ composer fix-cs)
    - Run ESLint and Prettier for new JS/SCSS code (use $ yarn fix)
    - Ask for a review (ping @ibexa/php-dev or @ibexa/javascript-dev depending on the changes) 
--> 
