### PR TITLE
[CS] Improved implementation of UserMetadata criterion parser

### DIFF
--- a/src/lib/Server/Input/Parser/Criterion/UserMetadata.php
+++ b/src/lib/Server/Input/Parser/Criterion/UserMetadata.php
@@ -17,16 +17,11 @@ use Ibexa\Rest\Input\BaseParser;
 class UserMetadata extends BaseParser
 {
     /**
-     * Parses input structure to a Criterion object.
-     *
-     * @param array $data
-     * @param \Ibexa\Contracts\Rest\Input\ParsingDispatcher $parsingDispatcher
+     * @phpstan-param array{UserMetadataCriterion: array{Target: string, Value: int|string|array}} $data
      *
      * @throws \Ibexa\Contracts\Rest\Exceptions\Parser
-     *
-     * @return \Ibexa\Contracts\Core\Repository\Values\Content\Query\Criterion\UserMetadata
      */
-    public function parse(array $data, ParsingDispatcher $parsingDispatcher)
+    public function parse(array $data, ParsingDispatcher $parsingDispatcher): UserMetadataCriterion
     {
         if (!isset($data['UserMetadataCriterion'])) {
             throw new Exceptions\Parser('Invalid <UserMetadataCriterion> format');
@@ -48,7 +43,7 @@ class UserMetadata extends BaseParser
 
         $value = is_array($data['UserMetadataCriterion']['Value'])
             ? $data['UserMetadataCriterion']['Value']
-            : explode(',', $data['UserMetadataCriterion']['Value']);
+            : explode(',', (string)$data['UserMetadataCriterion']['Value']);
 
         return new UserMetadataCriterion($target, null, $value);
     }


### PR DESCRIPTION
| :ticket: Issue | n/a |
|----------------|-----|


#### Description:

After PHPStan release we're getting new issue reported:
```
 ------ ------------------------------------------------------------------------- 
  Line   src/lib/Server/Input/Parser/Criterion/UserMetadata.php                   
 ------ ------------------------------------------------------------------------- 
  51     Parameter #2 $str of function explode expects string, int|string given.  
 ------ ------------------------------------------------------------------------- 

```

Seems there's an easy fix. This PR in general improves UserMetadata criterion parser code quality.

#### For QA:
Change to CS & internal code, no QA required.
