### PR TITLE
IBX-8825: Added `strict_mode` for REST API

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -56,19 +56,9 @@ parameters:
 			path: src/bundle/DependencyInjection/Compiler/ValueObjectVisitorPass.php
 
 		-
-			message: "#^Method Ibexa\\\\Bundle\\\\Rest\\\\DependencyInjection\\\\Configuration\\:\\:addRestRootResourcesSection\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: src/bundle/DependencyInjection/Configuration.php
-
-		-
 			message: "#^Method Ibexa\\\\Bundle\\\\Rest\\\\DependencyInjection\\\\Configuration\\:\\:addRestRootResourcesSection\\(\\) has parameter \\$rootNode with no type specified\\.$#"
 			count: 1
 			path: src/bundle/DependencyInjection/Configuration.php
-
-		-
-			message: "#^Method Ibexa\\\\Bundle\\\\Rest\\\\DependencyInjection\\\\IbexaRestExtension\\:\\:load\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: src/bundle/DependencyInjection/IbexaRestExtension.php
 
 		-
 			message: "#^Method Ibexa\\\\Bundle\\\\Rest\\\\DependencyInjection\\\\IbexaRestExtension\\:\\:prepend\\(\\) has no return type specified\\.$#"

--- a/src/bundle/DependencyInjection/Configuration.php
+++ b/src/bundle/DependencyInjection/Configuration.php
@@ -11,16 +11,25 @@ use Symfony\Component\Config\Definition\Builder\TreeBuilder;
 
 class Configuration extends SiteAccessConfiguration
 {
-    public function getConfigTreeBuilder()
+    public function getConfigTreeBuilder(): TreeBuilder
     {
         $treeBuilder = new TreeBuilder(IbexaRestExtension::EXTENSION_NAME);
 
-        $this->addRestRootResourcesSection($treeBuilder->getRootNode());
+        $rootNode = $treeBuilder->getRootNode();
+        $rootNode
+            ->children()
+                ->booleanNode('strict_mode')
+                    ->defaultValue('%kernel.debug%')
+                    ->info('Throw exceptions for missing normalizers.')
+                ->end()
+            ->end();
+
+        $this->addRestRootResourcesSection($rootNode);
 
         return $treeBuilder;
     }
 
-    public function addRestRootResourcesSection($rootNode)
+    private function addRestRootResourcesSection($rootNode): void
     {
         $systemNode = $this->generateScopeBaseNode($rootNode);
         $systemNode

--- a/src/bundle/DependencyInjection/IbexaRestExtension.php
+++ b/src/bundle/DependencyInjection/IbexaRestExtension.php
@@ -12,7 +12,7 @@ use Symfony\Component\Config\Resource\FileResource;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Extension\PrependExtensionInterface;
 use Symfony\Component\DependencyInjection\Loader;
-use Symfony\Component\HttpKernel\DependencyInjection\Extension;
+use Symfony\Component\HttpKernel\DependencyInjection\ConfigurableExtension;
 use Symfony\Component\Yaml\Yaml;
 
 /**
@@ -20,7 +20,7 @@ use Symfony\Component\Yaml\Yaml;
  *
  * To learn more see {@link http://symfony.com/doc/current/cookbook/bundles/extension.html}
  */
-class IbexaRestExtension extends Extension implements PrependExtensionInterface
+class IbexaRestExtension extends ConfigurableExtension implements PrependExtensionInterface
 {
     public const EXTENSION_NAME = 'ibexa_rest';
 
@@ -30,12 +30,11 @@ class IbexaRestExtension extends Extension implements PrependExtensionInterface
     }
 
     /**
-     * {@inheritdoc}
+     * @param array<string, mixed> $mergedConfig
      */
-    public function load(array $configs, ContainerBuilder $container)
+    protected function loadInternal(array $mergedConfig, ContainerBuilder $container): void
     {
-        $configuration = $this->getConfiguration($configs, $container);
-        $config = $this->processConfiguration($configuration, $configs);
+        $container->setParameter('ibexa.rest.strict_mode', $mergedConfig['strict_mode']);
 
         $loader = new Loader\YamlFileLoader($container, new FileLocator(__DIR__ . '/../Resources/config'));
         $loader->load('services.yml');
@@ -45,7 +44,7 @@ class IbexaRestExtension extends Extension implements PrependExtensionInterface
         $loader->load('default_settings.yml');
 
         $processor = new ConfigurationProcessor($container, 'ibexa.site_access.config');
-        $processor->mapConfigArray('rest_root_resources', $config);
+        $processor->mapConfigArray('rest_root_resources', $mergedConfig);
     }
 
     public function prepend(ContainerBuilder $container)

--- a/src/bundle/Resources/config/services.yml
+++ b/src/bundle/Resources/config/services.yml
@@ -344,6 +344,7 @@ services:
         arguments:
             $normalizer: '@ibexa.rest.serializer'
             $logger: '@logger'
+            $strictMode: '%ibexa.rest.strict_mode%'
         tags:
             - { name: monolog.logger, channel: ibexa.rest }
 
@@ -357,6 +358,7 @@ services:
         arguments:
             $normalizer: '@ibexa.rest.serializer'
             $logger: '@logger'
+            $strictMode: '%ibexa.rest.strict_mode%'
         tags:
             - { name: monolog.logger, channel: ibexa.rest }
 

--- a/src/lib/Output/Generator/Json/FieldTypeHashGenerator.php
+++ b/src/lib/Output/Generator/Json/FieldTypeHashGenerator.php
@@ -19,12 +19,16 @@ class FieldTypeHashGenerator implements LoggerAwareInterface
 
     private NormalizerInterface $normalizer;
 
+    private bool $strictMode;
+
     public function __construct(
         NormalizerInterface $normalizer,
-        ?LoggerInterface $logger = null
+        ?LoggerInterface $logger = null,
+        bool $strictMode = false
     ) {
         $this->normalizer = $normalizer;
         $this->logger = $logger ?? new NullLogger();
+        $this->strictMode = $strictMode;
     }
 
     /**
@@ -152,6 +156,9 @@ class FieldTypeHashGenerator implements LoggerAwareInterface
         try {
             $value = $this->normalizer->normalize($value, 'json', ['parent' => $parent]);
         } catch (ExceptionInterface $e) {
+            if ($this->strictMode) {
+                throw $e;
+            }
             $message = sprintf(
                 'Unable to normalize value for type "%s". %s. '
                 . 'Ensure that a normalizer is registered with tag: "%s".',

--- a/src/lib/Output/Generator/Xml/FieldTypeHashGenerator.php
+++ b/src/lib/Output/Generator/Xml/FieldTypeHashGenerator.php
@@ -19,12 +19,16 @@ class FieldTypeHashGenerator implements LoggerAwareInterface
 
     private NormalizerInterface $normalizer;
 
+    private bool $strictMode;
+
     public function __construct(
         NormalizerInterface $normalizer,
-        ?LoggerInterface $logger = null
+        ?LoggerInterface $logger = null,
+        bool $strictMode = false
     ) {
         $this->normalizer = $normalizer;
         $this->logger = $logger ?? new NullLogger();
+        $this->strictMode = $strictMode;
     }
 
     /**
@@ -243,6 +247,9 @@ class FieldTypeHashGenerator implements LoggerAwareInterface
         try {
             $value = $this->normalizer->normalize($value, 'xml');
         } catch (ExceptionInterface $e) {
+            if ($this->strictMode) {
+                throw $e;
+            }
             $message = sprintf(
                 'Unable to normalize value for type "%s". %s. '
                 . 'Ensure that a normalizer is registered with tag: "%s".',


### PR DESCRIPTION
| :ticket: Issue | IBX-8825 |
|----------------|-----------|

<!-- 
#### Related PRs: 
- https://github.com/ibexa/core/pull/1
-->

#### Description:
This PR introduces the concept of `strict_mode` for REST.

In `strict_mode`, when REST processing encounters an error/exception that it previously silenced (and usually logged as an error) it will re-throw it.

#### For QA:
> [!NOTE]
> This functionality needs to be tested separately on `prod` and `dev` application environments.

#### Documentation:
<!-- Optional. Replace this comment with details helpful for writing the doc: overview, code snippets for extensibility etc. -->


<!-- 
Before you click submit:
    - Test the solution manually
    - Provide automated test coverage
    - Confirm that target branch is set correctly
    - Run PHP CS Fixer for new PHP code (use $ composer fix-cs)
    - Run ESLint and Prettier for new JS/SCSS code (use $ yarn fix)
    - Ask for a review (ping @ibexa/php-dev or @ibexa/javascript-dev depending on the changes) 
--> 
