### PR TITLE
Added missing strict types declaration to BaseCriterionProcessor

### DIFF
--- a/src/contracts/Input/Parser/Query/Criterion/BaseCriterionProcessor.php
+++ b/src/contracts/Input/Parser/Query/Criterion/BaseCriterionProcessor.php
@@ -4,6 +4,8 @@
  * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+declare(strict_types=1);
+
 namespace Ibexa\Contracts\Rest\Input\Parser\Query\Criterion;
 
 use Ibexa\Contracts\Rest\Exceptions;


### PR DESCRIPTION
| :ticket: Issue | IBX-8596 |
|----------------|-----------|

#### Related PRs: 
- #116
- blocks CI of #118

#### Description:

Not sure if this was intentional, but seems we're missing `declare(strict_types=1)` in `BaseCriterionProcessor` introduced via #116.

On `main` it causes [code style check failure](https://github.com/ibexa/rest/actions/runs/10603436002/job/29387755775?pr=118#step:5:16) and blocks CI of #118.

