### PR TITLE
IBX-8535: Deprecate RequestParser and implementations

### DIFF
--- a/src/lib/RequestParser.php
+++ b/src/lib/RequestParser.php
@@ -9,8 +9,7 @@ namespace Ibexa\Rest;
 /**
  * Interface for Request parsers.
  *
- * @deprecated 4.6.11
- * use \Ibexa\Contracts\Rest\UriParser\UriParserInterface and \Symfony\Component\Routing\RouterInterface instead
+ * @deprecated 4.6.11 The \Ibexa\Rest\RequestParser is deprecated, will be removed in 5.0.0. Use \Ibexa\Contracts\Rest\UriParser\UriParserInterface and \Symfony\Component\Routing\RouterInterface instead.
  */
 interface RequestParser
 {

--- a/src/lib/RequestParser.php
+++ b/src/lib/RequestParser.php
@@ -8,6 +8,9 @@ namespace Ibexa\Rest;
 
 /**
  * Interface for Request parsers.
+ *
+ * @deprecated 4.6.11
+ * use \Ibexa\Contracts\Rest\UriParser\UriParserInterface and \Symfony\Component\Routing\RouterInterface instead
  */
 interface RequestParser
 {

--- a/src/lib/RequestParser/EzPublish.php
+++ b/src/lib/RequestParser/EzPublish.php
@@ -7,6 +7,8 @@
 namespace Ibexa\Rest\RequestParser;
 
 /**
+ * @deprecated 4.6.11, and will be removed in the next major release.
+ *
  * Pattern based Request parser pre-configured for Ibexa.
  */
 class EzPublish extends Pattern

--- a/src/lib/RequestParser/EzPublish.php
+++ b/src/lib/RequestParser/EzPublish.php
@@ -7,7 +7,7 @@
 namespace Ibexa\Rest\RequestParser;
 
 /**
- * @deprecated 4.6.11, and will be removed in the next major release.
+ * @deprecated 4.6.11 The \Ibexa\Rest\RequestParser\EzPublish is deprecated, will be removed in 5.0.0.
  *
  * Pattern based Request parser pre-configured for Ibexa.
  */

--- a/src/lib/RequestParser/Pattern.php
+++ b/src/lib/RequestParser/Pattern.php
@@ -10,6 +10,8 @@ use Ibexa\Contracts\Rest\Exceptions;
 use Ibexa\Rest\RequestParser;
 
 /**
+ * @deprecated 4.6.11, and will be removed in the next major release.
+ *
  * Pattern based Request parser.
  *
  * Handles 2 types of patterns to be used in an URL:

--- a/src/lib/RequestParser/Pattern.php
+++ b/src/lib/RequestParser/Pattern.php
@@ -10,7 +10,7 @@ use Ibexa\Contracts\Rest\Exceptions;
 use Ibexa\Rest\RequestParser;
 
 /**
- * @deprecated 4.6.11, and will be removed in the next major release.
+ * @deprecated 4.6.11 The \Ibexa\Rest\RequestParser\Pattern is deprecated, will be removed in 5.0.0.
  *
  * Pattern based Request parser.
  *


### PR DESCRIPTION
| :ticket: Issue | IBX-8535 |
|----------------|-----------|

<!-- 
#### Related PRs: 
- https://github.com/ibexa/core/pull/1
-->

#### Description:
During removing deprecated `\Ibexa\Bundle\Rest\RequestParser\Router` it turned out, it does not make much sense to keep interface and other unused implementations.

#### For QA:
<!-- Optional. Replace this comment with any necessary information needed by QA to test this Pull Request -->

#### Documentation:
<!-- Optional. Replace this comment with details helpful for writing the doc: overview, code snippets for extensibility etc. -->


<!-- 
Before you click submit:
    - Test the solution manually
    - Provide automated test coverage
    - Confirm that target branch is set correctly
    - Run PHP CS Fixer for new PHP code (use $ composer fix-cs)
    - Run ESLint and Prettier for new JS/SCSS code (use $ yarn fix)
    - Ask for a review (ping @ibexa/php-dev or @ibexa/javascript-dev depending on the changes) 
--> 
