### PR TITLE
RFC: Move REST route recognition after routing resolves

### DIFF
--- a/src/bundle/EventListener/RequestListener.php
+++ b/src/bundle/EventListener/RequestListener.php
@@ -62,7 +62,7 @@ class RequestListener implements EventSubscriberInterface
 
     public function addAttributeForIbexaRestRoute(RequestEvent $event): void
     {
-        $path = $event->getRequest()->attributes->get('semanticPathInfo');
+        $path = $event->getRequest()->attributes->get('semanticPathinfo');
         if ($path === null) {
             return;
         }

--- a/src/bundle/EventListener/RequestListener.php
+++ b/src/bundle/EventListener/RequestListener.php
@@ -62,7 +62,11 @@ class RequestListener implements EventSubscriberInterface
 
     public function addAttributeForIbexaRestRoute(RequestEvent $event): void
     {
-        $path = $event->getRequest()->attributes->get('semanticPathinfo');
+        $path = $event->getRequest()->attributes->get('semanticPathInfo');
+        if ($path === null) {
+            return;
+        }
+
         $event->getRequest()->attributes->set(
             'is_rest_request',
             $this->uriParser->hasRestPrefix($path)

--- a/src/bundle/EventListener/RequestListener.php
+++ b/src/bundle/EventListener/RequestListener.php
@@ -42,7 +42,10 @@ class RequestListener implements EventSubscriberInterface
     {
         return [
             // 10001 is to ensure that REST requests are tagged before CorsListener is called
-            KernelEvents::REQUEST => ['onKernelRequest', 10001],
+            KernelEvents::REQUEST => [
+                ['onKernelRequest', 10001],
+                ['addAttributeForIbexaRestRoute', 30],
+            ],
         ];
     }
 
@@ -54,6 +57,15 @@ class RequestListener implements EventSubscriberInterface
         $event->getRequest()->attributes->set(
             'is_rest_request',
             $this->uriParser->isRestRequest($event->getRequest())
+        );
+    }
+
+    public function addAttributeForIbexaRestRoute(RequestEvent $event): void
+    {
+        $path = $event->getRequest()->attributes->get('semanticPathinfo');
+        $event->getRequest()->attributes->set(
+            'is_rest_request',
+            $this->uriParser->hasRestPrefix($path)
         );
     }
 

--- a/tests/bundle/EventListener/EventListenerTest.php
+++ b/tests/bundle/EventListener/EventListenerTest.php
@@ -49,8 +49,18 @@ abstract class EventListenerTest extends TestCase
 
         // Check that referenced methods exist
         foreach ($supportedEvents as $method) {
+            // Multiple events, or single event with priority
+            if (is_array($method)) {
+                $method = $method[0];
+            }
+
+            // Multiple events with priorities
+            if (is_array($method)) {
+                $method = $method[0];
+            }
+
             self::assertTrue(
-                method_exists($eventListener, is_array($method) ? $method[0] : $method)
+                method_exists($eventListener, $method)
             );
         }
     }

--- a/tests/bundle/EventListener/RequestListenerTest.php
+++ b/tests/bundle/EventListener/RequestListenerTest.php
@@ -40,6 +40,7 @@ final class RequestListenerTest extends EventListenerTest
             // REST requests
             [self::REST_ROUTE, true],
             ['/api/ibexa/v2/true', true],
+            ['/admin/api/ibexa/v2/true', true],
             ['/api/bundle-name/v2/true', true],
             ['/api/MyBundle12/v2/true', true],
             ['/api/ThisIs_Bundle123/v2/true', true],
@@ -95,13 +96,20 @@ final class RequestListenerTest extends EventListenerTest
 
     protected function performFakeRequest(string $uri, int $type = HttpKernelInterface::MAIN_REQUEST): Request
     {
+        $request = Request::create($uri);
         $event = new RequestEvent(
             $this->createMock(HttpKernelInterface::class),
-            Request::create($uri),
+            $request,
             $type
         );
 
         $this->getEventListener()->onKernelRequest($event);
+
+        if (str_starts_with($uri, '/admin')) {
+            $uri = substr($uri, strlen('/admin'));
+        }
+        $request->attributes->set('semanticPathInfo', $uri);
+        $this->getEventListener()->addAttributeForIbexaRestRoute($event);
 
         return $event->getRequest();
     }

--- a/tests/bundle/EventListener/RequestListenerTest.php
+++ b/tests/bundle/EventListener/RequestListenerTest.php
@@ -108,7 +108,7 @@ final class RequestListenerTest extends EventListenerTest
         if (str_starts_with($uri, '/admin')) {
             $uri = substr($uri, strlen('/admin'));
         }
-        $request->attributes->set('semanticPathInfo', $uri);
+        $request->attributes->set('semanticPathinfo', $uri);
         $this->getEventListener()->addAttributeForIbexaRestRoute($event);
 
         return $event->getRequest();


### PR DESCRIPTION
| :ticket: Issue | N/A |
|----------------|-----------|

<!-- 
#### Related PRs: 
- https://github.com/ibexa/core/pull/1
-->

#### Description:
This PR adds a secondary check for REST API route after routing has been resolved.

This allows routes like `/admin/api/ibexa/v2` to work.

> [!NOTE]
> I removed the original method completely (`onKernelRequest`) and REST API remained functional.

#### For QA:
<!-- Optional. Replace this comment with any necessary information needed by QA to test this Pull Request -->

#### Documentation:
<!-- Optional. Replace this comment with details helpful for writing the doc: overview, code snippets for extensibility etc. -->


<!-- 
Before you click submit:
    - Test the solution manually
    - Provide automated test coverage
    - Confirm that target branch is set correctly
    - Run PHP CS Fixer for new PHP code (use $ composer fix-cs)
    - Run ESLint and Prettier for new JS/SCSS code (use $ yarn fix)
    - Ask for a review (ping @ibexa/php-dev or @ibexa/javascript-dev depending on the changes) 
--> 
