### PR TITLE
IBX-8603: Allow deeper media-type granulation

### DIFF
--- a/src/bundle/Resources/config/services.yml
+++ b/src/bundle/Resources/config/services.yml
@@ -1,9 +1,9 @@
 parameters:
     ibexa.rest.output.visitor.json.regexps:
-        - '(^application/vnd\.ibexa\.api\.[A-Za-z]+\+json$)'
+        - '(^application/vnd\.ibexa\.api(\.[A-Za-z]+)+\+json$)'
         - '(^application/json$)'
     ibexa.rest.output.visitor.xml.regexps:
-        - '(^application/vnd\.ibexa\.api\.[A-Za-z]+\+xml$)'
+        - '(^application/vnd\.ibexa\.api(\.[A-Za-z]+)+\+xml$)'
         - '(^application/xml$)'
         - '(^.*/.*$)'
     ibexa.rest.path_prefix.pattern: !php/const \Ibexa\Bundle\Rest\UriParser\UriParser::DEFAULT_REST_PREFIX_PATTERN


### PR DESCRIPTION
| :ticket: Issue | IBX-8603 |
|----------------|-----------|


#### Related PRs: 
- https://github.com/ibexa/connector-ai/pull/21


#### Description:
Allow deeper media-type granulation, like ie. `application/vnd.ibexa.api.ai.DoSomething+json`. Otherwise we would need to distingish mediatypes with prefix, like `AIDoSomething`. While `DoSomething` is meaningless example; PR makes more sense if we consider `application/vnd.ibexa.api.ai.CreateContent+json` a possible and valid feature.

Change is BC safe.
<!-- Replace this comment with Pull Request description. Include screenshots for design changes. -->

#### For QA:
<!-- Optional. Replace this comment with any necessary information needed by QA to test this Pull Request -->

#### Documentation:
<!-- Optional. Replace this comment with details helpful for writing the doc: overview, code snippets for extensibility etc. -->


<!-- 
Before you click submit:
    - Test the solution manually
    - Provide automated test coverage
    - Confirm that target branch is set correctly
    - Run PHP CS Fixer for new PHP code (use $ composer fix-cs)
    - Run ESLint and Prettier for new JS/SCSS code (use $ yarn fix)
    - Ask for a review (ping @ibexa/php-dev or @ibexa/javascript-dev depending on the changes) 
--> 
