### PR TITLE
IBX-8534: Dropped usage of deprecated contentService::loadContentDrafts method

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1751,11 +1751,6 @@ parameters:
 			path: src/lib/Server/Controller/User.php
 
 		-
-			message: "#^Parameter \\#1 \\$versions of class Ibexa\\\\Rest\\\\Server\\\\Values\\\\VersionList constructor expects array\\<Ibexa\\\\Contracts\\\\Core\\\\Repository\\\\Values\\\\Content\\\\VersionInfo\\>, iterable\\<Ibexa\\\\Contracts\\\\Core\\\\Repository\\\\Values\\\\Content\\\\VersionInfo\\> given\\.$#"
-			count: 1
-			path: src/lib/Server/Controller/User.php
-
-		-
 			message: "#^Parameter \\#5 \\$relations of class Ibexa\\\\Rest\\\\Server\\\\Values\\\\RestUser constructor expects array\\<Ibexa\\\\Contracts\\\\Core\\\\Repository\\\\Values\\\\Content\\\\Relation\\>, iterable\\<Ibexa\\\\Contracts\\\\Core\\\\Repository\\\\Values\\\\Content\\\\Relation\\> given\\.$#"
 			count: 5
 			path: src/lib/Server/Controller/User.php

--- a/src/lib/Server/Controller/User.php
+++ b/src/lib/Server/Controller/User.php
@@ -17,7 +17,9 @@ use Ibexa\Contracts\Core\Repository\Repository;
 use Ibexa\Contracts\Core\Repository\RoleService;
 use Ibexa\Contracts\Core\Repository\SectionService;
 use Ibexa\Contracts\Core\Repository\UserService;
+use Ibexa\Contracts\Core\Repository\Values\Content\DraftList\ContentDraftListItemInterface;
 use Ibexa\Contracts\Core\Repository\Values\Content\Language;
+use Ibexa\Contracts\Core\Repository\Values\Content\VersionInfo;
 use Ibexa\Contracts\Core\Repository\Values\User\User as RepositoryUser;
 use Ibexa\Contracts\Core\Repository\Values\User\UserGroupRoleAssignment;
 use Ibexa\Contracts\Core\Repository\Values\User\UserRoleAssignment;
@@ -577,11 +579,17 @@ final class User extends RestController
      */
     public function loadUserDrafts(int $userId, Request $request): Values\VersionList
     {
-        $contentDrafts = $this->contentService->loadContentDrafts(
+        $contentDrafts = $this->contentService->loadContentDraftList(
             $this->userService->loadUser($userId)
         );
 
-        return new Values\VersionList($contentDrafts, $request->getPathInfo());
+        return new Values\VersionList(
+            array_map(
+                static fn (ContentDraftListItemInterface $draftListItem): VersionInfo => $draftListItem->getVersionInfo(),
+                $contentDrafts->items
+            ),
+            $request->getPathInfo()
+        );
     }
 
     /**

--- a/src/lib/Server/Controller/User.php
+++ b/src/lib/Server/Controller/User.php
@@ -584,10 +584,10 @@ final class User extends RestController
         );
 
         return new Values\VersionList(
-            array_map(
-                static fn (ContentDraftListItemInterface $draftListItem): VersionInfo => $draftListItem->getVersionInfo(),
+            array_filter(array_map(
+                static fn (ContentDraftListItemInterface $draftListItem): ?VersionInfo => $draftListItem->getVersionInfo(),
                 $contentDrafts->items
-            ),
+            )),
             $request->getPathInfo()
         );
     }


### PR DESCRIPTION
| :ticket: Issue | IBX-8534 |
|----------------|-----------|

<!-- 
#### Related PRs: 
- https://github.com/ibexa/core/pull/1
-->

#### Description:
<!-- Replace this comment with Pull Request description. Include screenshots for design changes. -->

#### For QA:
<!-- Optional. Replace this comment with any necessary information needed by QA to test this Pull Request -->

#### Documentation:
<!-- Optional. Replace this comment with details helpful for writing the doc: overview, code snippets for extensibility etc. -->


<!-- 
Before you click submit:
    - Test the solution manually
    - Provide automated test coverage
    - Confirm that target branch is set correctly
    - Run PHP CS Fixer for new PHP code (use $ composer fix-cs)
    - Run ESLint and Prettier for new JS/SCSS code (use $ yarn fix)
    - Ask for a review (ping @ibexa/php-dev or @ibexa/javascript-dev depending on the changes) 
--> 
