### PR TITLE
Enhance PHPDoc

### DIFF
--- a/src/contracts/Exceptions/NotFoundException.php
+++ b/src/contracts/Exceptions/NotFoundException.php
@@ -9,10 +9,10 @@ namespace Ibexa\Contracts\Rest\Exceptions;
 use Ibexa\Contracts\Core\Repository\Exceptions\NotFoundException as APINotFoundException;
 
 /**
- * Implementation of the {@link \Ibexa\Contracts\Core\Repository\Exceptions\NotFoundException}
- * interface.
+ * REST API equivalent of PHP API's NotFoundException.
  *
- * @see \Ibexa\Contracts\Core\Repository\Exceptions\NotFoundException
+ * Implementation of the {@see \Ibexa\Contracts\Core\Repository\Exceptions\NotFoundException}
+ * interface.
  */
 class NotFoundException extends APINotFoundException
 {


### PR DESCRIPTION
| :ticket: Issue | IBX-XXXXX |
|----------------|-----------|

#### Related PRs: 

- ibexa/core#463
- ibexa/payment#161

##### Preview

- `Ibexa\Contracts\Rest\Exceptions\NotFoundException`
    - [Before](https://doc.ibexa.co/en/latest/api/php_api/php_api_reference/classes/Ibexa-Contracts-Rest-Exceptions-NotFoundException.html) has a not-rendered `@see` in its summary.
    - [After](https://ez-systems-developer-documentation--2583.com.readthedocs.build/en/2583/api/php_api/php_api_reference/classes/Ibexa-Contracts-Rest-Exceptions-NotFoundException.html) has a new summary, and description with a link.

#### Description:

A DocBlock summary line can't have formatting, it isn't rendered.
Add missing summary line for proper rendering.

See ibexa/core#463 for more.

#### For QA:
<!-- Optional. Replace this comment with any necessary information needed by QA to test this Pull Request -->

#### Documentation:
<!-- Optional. Replace this comment with details helpful for writing the doc: overview, code snippets for extensibility etc. -->


<!-- 
Before you click submit:
    - Test the solution manually
    - Provide automated test coverage
    - Confirm that target branch is set correctly
    - Run PHP CS Fixer for new PHP code (use $ composer fix-cs)
    - Run ESLint and Prettier for new JS/SCSS code (use $ yarn fix)
    - Ask for a review (ping @ibexa/php-dev or @ibexa/javascript-dev depending on the changes) 
--> 
