### PR TITLE
IBX-9587: Fixed failing REST requests after Symfony 6 upgrade

### DIFF
--- a/src/bundle/Resources/config/routing.yml
+++ b/src/bundle/Resources/config/routing.yml
@@ -40,7 +40,7 @@ ibexa.rest.delete_section:
 
 ibexa.rest.refresh_session:
     path: /user/sessions/{sessionId}/refresh
-    controller: Ibexa\Rest\Server\Controller\SessionController:refreshSessionAction
+    controller: Ibexa\Rest\Server\Controller\SessionController::refreshSessionAction
     defaults:
         csrf_protection: false
     methods: [POST]

--- a/src/bundle/Routing/OptionsLoader/Mapper.php
+++ b/src/bundle/Routing/OptionsLoader/Mapper.php
@@ -14,18 +14,13 @@ use Symfony\Component\Routing\Route;
  */
 class Mapper
 {
-    /**
-     * @param $route Route REST route
-     *
-     * @return \Symfony\Component\Routing\Route
-     */
-    public function mapRoute(Route $route)
+    public function mapRoute(Route $route): Route
     {
         $optionsRoute = clone $route;
         $optionsRoute->setMethods(['OPTIONS']);
         $optionsRoute->setDefault(
             '_controller',
-            'Ibexa\Rest\Server\Controller\Options:getRouteOptions'
+            'Ibexa\Rest\Server\Controller\Options::getRouteOptions'
         );
 
         $optionsRoute->setDefault(

--- a/tests/bundle/Functional/BookmarkTest.php
+++ b/tests/bundle/Functional/BookmarkTest.php
@@ -13,6 +13,9 @@ use Symfony\Component\HttpFoundation\Response;
 
 class BookmarkTest extends RESTFunctionalTestCase
 {
+    /**
+     * @throws \Psr\Http\Client\ClientExceptionInterface
+     */
     public function testCreateBookmark(): int
     {
         $content = $this->createFolder(__FUNCTION__, '/api/ibexa/v2/content/locations/1/2');
@@ -28,13 +31,15 @@ class BookmarkTest extends RESTFunctionalTestCase
 
         $response = $this->sendHttpRequest($request);
 
-        self::assertHttpResponseCodeEquals($response, Response::HTTP_CREATED);
+        $this->assertHttpResponseCodeEquals($response, Response::HTTP_CREATED);
 
         return $locationId;
     }
 
     /**
      * @depends testCreateBookmark
+     *
+     * @throws \Psr\Http\Client\ClientExceptionInterface
      */
     public function testCreateBookmarkIfAlreadyExists(int $locationId): void
     {
@@ -45,11 +50,13 @@ class BookmarkTest extends RESTFunctionalTestCase
 
         $response = $this->sendHttpRequest($request);
 
-        self::assertHttpResponseCodeEquals($response, Response::HTTP_CONFLICT);
+        $this->assertHttpResponseCodeEquals($response, Response::HTTP_CONFLICT);
     }
 
     /**
      * @depends testCreateBookmark
+     *
+     * @throws \Psr\Http\Client\ClientExceptionInterface
      */
     public function testIsBookmarked(int $locationId): void
     {
@@ -60,13 +67,16 @@ class BookmarkTest extends RESTFunctionalTestCase
 
         $response = $this->sendHttpRequest($request);
 
-        self::assertHttpResponseCodeEquals($response, Response::HTTP_OK);
+        $this->assertHttpResponseCodeEquals($response, Response::HTTP_OK);
     }
 
-    public function testIsBookmarkedReturnsNotFound(): void
+    /**
+     * @depends testDeleteBookmark
+     *
+     * @throws \Psr\Http\Client\ClientExceptionInterface
+     */
+    public function testIsBookmarkedReturnsNotFound(int $locationId): void
     {
-        $locationId = 43;
-
         $request = $this->createHttpRequest(
             'HEAD',
             '/api/ibexa/v2/bookmark/' . $locationId
@@ -74,13 +84,15 @@ class BookmarkTest extends RESTFunctionalTestCase
 
         $response = $this->sendHttpRequest($request);
 
-        self::assertHttpResponseCodeEquals($response, Response::HTTP_NOT_FOUND);
+        $this->assertHttpResponseCodeEquals($response, Response::HTTP_NOT_FOUND);
     }
 
     /**
      * @depends testCreateBookmark
+     *
+     * @throws \Psr\Http\Client\ClientExceptionInterface
      */
-    public function testDeleteBookmark(int $locationId): void
+    public function testDeleteBookmark(int $locationId): int
     {
         $request = $this->createHttpRequest(
             'DELETE',
@@ -89,9 +101,14 @@ class BookmarkTest extends RESTFunctionalTestCase
 
         $response = $this->sendHttpRequest($request);
 
-        self::assertHttpResponseCodeEquals($response, Response::HTTP_NO_CONTENT);
+        $this->assertHttpResponseCodeEquals($response, Response::HTTP_NO_CONTENT);
+
+        return $locationId;
     }
 
+    /**
+     * @throws \Psr\Http\Client\ClientExceptionInterface
+     */
     public function testLoadBookmarks(): void
     {
         $request = $this->createHttpRequest(
@@ -103,13 +120,16 @@ class BookmarkTest extends RESTFunctionalTestCase
 
         $response = $this->sendHttpRequest($request);
 
-        self::assertHttpResponseCodeEquals($response, Response::HTTP_OK);
+        $this->assertHttpResponseCodeEquals($response, Response::HTTP_OK);
     }
 
-    public function testDeleteBookmarkReturnNotFound(): void
+    /**
+     * @depends testDeleteBookmark
+     *
+     * @throws \Psr\Http\Client\ClientExceptionInterface
+     */
+    public function testDeleteBookmarkReturnNotFound(int $locationId): void
     {
-        $locationId = 43;
-
         $request = $this->createHttpRequest(
             'DELETE',
             '/api/ibexa/v2/bookmark/' . $locationId
@@ -117,6 +137,6 @@ class BookmarkTest extends RESTFunctionalTestCase
 
         $response = $this->sendHttpRequest($request);
 
-        self::assertHttpResponseCodeEquals($response, Response::HTTP_NOT_FOUND);
+        $this->assertHttpResponseCodeEquals($response, Response::HTTP_NOT_FOUND);
     }
 }

--- a/tests/bundle/Functional/LocationTest.php
+++ b/tests/bundle/Functional/LocationTest.php
@@ -21,7 +21,7 @@ class LocationTest extends RESTFunctionalTestCase
         $content = $this->createFolder('testCreateLocation', '/api/ibexa/v2/content/locations/1/2');
         $contentHref = $content['_href'];
 
-        $remoteId = $this->addTestSuffix('testCreatelocation');
+        $remoteId = $this->addTestSuffix('testCreateLocation');
 
         $body = <<< XML
 <?xml version="1.0" encoding="UTF-8"?>

--- a/tests/bundle/Routing/OptionsLoader/MapperTest.php
+++ b/tests/bundle/Routing/OptionsLoader/MapperTest.php
@@ -77,7 +77,7 @@ class MapperTest extends TestCase
         );
 
         self::assertEquals(
-            'Ibexa\Rest\Server\Controller\Options:getRouteOptions',
+            'Ibexa\Rest\Server\Controller\Options::getRouteOptions',
             $optionsRoute->getDefault('_controller')
         );
     }


### PR DESCRIPTION
| :ticket: Issue | IBX-9587 |
|----------------|-----------|


#### Related PRs: 
- https://github.com/ibexa/rest/pull/138


#### Description:

This is a follow-up to Symfony 6 upgrade (#138). Fixing issues that surfaced via the functional tests after merging full-stack app.

##### Issue 1: OPTIONS requests single-colon controller reference

`OPTIONS` requests controller mapper used obsolete single-colon controller reference that stopped working in Symfony 6.

##### Issue 2: Obsolete single-colon refresh session controller reference 

`SessionController::refreshSessionAction` controller used obsolete single-colon reference as well.

##### Test & code quality issues

- `LocationTest` created suffix using mismatched case in one place `testCreatelocation` instead of `testCreateLocation` which made tests fail on PostgreSQL instance (not visible in tests, noticed by accident). In short: it created `testCreateLocation*` remote ID but queried for `testCreatelocation*` remote ID, which doesn't work on case-sensitive PostgreSQL.
- Made `BookmarkTest` `testDeleteBookmarkReturnNotFound` and `testIsBookmarkedReturnsNotFound` not rely on hard-coded pre-defined database ID, as it's quite volatile. Some other tests at some point make this Location bookmarked and thus running the same test without resetting the database is impossible. Instead I made these tests dependent on `testDeleteBookmark` to check it against just deleted bookmark.
- Improved `BookmarkTest` code quality.

#### For QA:

Requires REST client.

##### Ad Issue 1. OPTIONS request

1. Try executing OPTIONS REST request on any REST route, e.g. a Root one `/api/ibexa/v2/`
2. Observe an error

##### Ad Issue 2. Session Refresh

1. Create a new session using `POST` `/api/ibexa/v2/user/sessions` with a proper payload and copy created session ID
2. Try executing `POST` `/api/ibexa/v2/user/sessions/<your_session_id>/refresh`
3. Observe a fatal error
