### PR TITLE
 IBX-9584: Resolved Symfony 6.x deprecations

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -29,6 +29,31 @@ jobs:
             - name: Run code style check
               run: composer run-script check-cs -- --format=checkstyle | cs2pr
 
+    rector:
+        name: Run rector
+        runs-on: "ubuntu-22.04"
+        strategy:
+            matrix:
+                php:
+                    - '8.3'
+        steps:
+            -   uses: actions/checkout@v4
+
+            -   name: Setup PHP Action
+                uses: shivammathur/setup-php@v2
+                with:
+                    php-version: ${{ matrix.php }}
+                    coverage: none
+                    extensions: 'pdo_sqlite, gd'
+                    tools: cs2pr
+
+            -   uses: ramsey/composer-install@v3
+                with:
+                    dependency-versions: highest
+
+            -   name: Run rector
+                run: vendor/bin/rector process --dry-run --ansi
+
     tests:
         name: Unit & integration tests
         runs-on: "ubuntu-22.04"

--- a/composer.json
+++ b/composer.json
@@ -48,6 +48,7 @@
     "require-dev": {
         "ibexa/code-style": "~2.0.0",
         "ibexa/doctrine-schema": "~5.0.x-dev",
+        "ibexa/rector": "~5.0.x-dev",
         "ibexa/test-core": "~5.0.x-dev",
         "justinrainbow/json-schema": "^5.2",
         "matthiasnoback/symfony-dependency-injection-test": "^4.1",

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -216,6 +216,11 @@ parameters:
 			path: src/contracts/Output/Visitor.php
 
 		-
+			message: "#^Method Symfony\\\\Component\\\\Serializer\\\\Normalizer\\\\NormalizerInterface\\:\\:supportsNormalization\\(\\) invoked with 3 parameters, 1\\-2 required\\.$#"
+			count: 1
+			path: src/contracts/Output/VisitorAdapterNormalizer.php
+
+		-
 			message: "#^Method Ibexa\\\\Rest\\\\FieldTypeProcessor\\\\BaseRelationProcessor\\:\\:setLocationService\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: src/lib/FieldTypeProcessor/BaseRelationProcessor.php

--- a/rector.php
+++ b/rector.php
@@ -20,4 +20,6 @@ return RectorConfig::configure()
         SymfonySetList::SYMFONY_60,
         SymfonySetList::SYMFONY_61,
         SymfonySetList::SYMFONY_62,
+        SymfonySetList::SYMFONY_63,
+        SymfonySetList::SYMFONY_64,
     ]);

--- a/rector.php
+++ b/rector.php
@@ -1,0 +1,23 @@
+<?php
+
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+use Ibexa\Contracts\Rector\Sets\IbexaSetList;
+use Rector\Config\RectorConfig;
+use Rector\Symfony\Set\SymfonySetList;
+
+return RectorConfig::configure()
+    ->withPaths([
+        __DIR__ . '/src',
+        __DIR__ . '/tests',
+    ])
+    ->withSets([
+        IbexaSetList::IBEXA_50->value,
+        SymfonySetList::SYMFONY_60,
+        SymfonySetList::SYMFONY_61,
+        SymfonySetList::SYMFONY_62,
+    ]);

--- a/src/bundle/EventListener/UserCheckRequestListener.php
+++ b/src/bundle/EventListener/UserCheckRequestListener.php
@@ -12,11 +12,11 @@ use Ibexa\Bundle\Rest\Exception\UnexpectedUserException;
 use Ibexa\Contracts\Core\Repository\PermissionResolver;
 use Psr\Log\LoggerAwareInterface;
 use Psr\Log\LoggerAwareTrait;
+use Symfony\Bundle\SecurityBundle\Security;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Event\RequestEvent;
 use Symfony\Component\HttpKernel\KernelEvents;
-use Symfony\Component\Security\Core\Security;
 
 final class UserCheckRequestListener implements EventSubscriberInterface, LoggerAwareInterface
 {

--- a/src/contracts/Output/VisitorAdapterNormalizer.php
+++ b/src/contracts/Output/VisitorAdapterNormalizer.php
@@ -12,12 +12,11 @@ use Ibexa\Contracts\Rest\Output\Generator as BaseGenerator;
 use Ibexa\Rest\Output\Generator;
 use LogicException;
 use Symfony\Component\Serializer\Encoder\EncoderInterface;
-use Symfony\Component\Serializer\Normalizer\ContextAwareNormalizerInterface;
 use Symfony\Component\Serializer\Normalizer\NormalizerAwareInterface;
 use Symfony\Component\Serializer\Normalizer\NormalizerAwareTrait;
 use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
 
-final class VisitorAdapterNormalizer implements NormalizerInterface, NormalizerAwareInterface, ContextAwareNormalizerInterface
+final class VisitorAdapterNormalizer implements NormalizerInterface, NormalizerAwareInterface
 {
     use NormalizerAwareTrait;
 
@@ -35,11 +34,9 @@ final class VisitorAdapterNormalizer implements NormalizerInterface, NormalizerA
     /**
      * @param array<string, mixed> $context
      *
-     * @throws \LogicException
-     *
-     * {@inheritDoc}
+     * @throws \Symfony\Component\Serializer\Exception\ExceptionInterface
      */
-    public function normalize(mixed $object, ?string $format = null, array $context = []): mixed
+    public function normalize(mixed $object, ?string $format = null, array $context = []): array|bool|string|int|float|null|\ArrayObject
     {
         $eligibleVisitor = is_object($object)
             ? $this->valueObjectVisitorResolver->resolveValueObjectVisitor($object)
@@ -69,12 +66,12 @@ final class VisitorAdapterNormalizer implements NormalizerInterface, NormalizerA
             return true;
         }
 
-        if (!$this->normalizer instanceof ContextAwareNormalizerInterface) {
+        if (!$this->normalizer instanceof NormalizerInterface) {
             throw new LogicException(
                 sprintf(
                     'Normalizer "%s" must be an instance of "%s".',
                     $this->normalizer::class,
-                    ContextAwareNormalizerInterface::class,
+                    NormalizerInterface::class,
                 ),
             );
         }

--- a/src/lib/Security/AuthorizationHeaderRESTRequestMatcher.php
+++ b/src/lib/Security/AuthorizationHeaderRESTRequestMatcher.php
@@ -9,33 +9,20 @@ declare(strict_types=1);
 namespace Ibexa\Rest\Security;
 
 use Symfony\Component\HttpFoundation\Request;
-use Symfony\Component\HttpFoundation\RequestMatcher;
+use Symfony\Component\HttpFoundation\RequestMatcherInterface;
 
 /**
  * @internal
  *
  * This class is mandatory for JWT REST calls recognition. It's used within security.firewalls.ibexa_jwt_rest.request_matcher configuration key.
  */
-final class AuthorizationHeaderRESTRequestMatcher extends RequestMatcher
+final class AuthorizationHeaderRESTRequestMatcher implements RequestMatcherInterface
 {
-    private ?string $headerName;
+    private const string DEFAULT_HEADER_NAME = 'Authorization';
 
-    /**
-     * @param array<string, mixed> $attributes
-     */
     public function __construct(
-        ?string $headerName = null,
-        string $path = null,
-        string $host = null,
-        $methods = null,
-        $ips = null,
-        array $attributes = [],
-        $schemes = null,
-        int $port = null
+        private ?string $headerName = null,
     ) {
-        parent::__construct($path, $host, $methods, $ips, $attributes, $schemes, $port);
-
-        $this->headerName = $headerName;
     }
 
     public function matches(Request $request): bool
@@ -44,10 +31,6 @@ final class AuthorizationHeaderRESTRequestMatcher extends RequestMatcher
             return false;
         }
 
-        if (!empty($request->headers->get($this->headerName ?? 'Authorization'))) {
-            return parent::matches($request);
-        }
-
-        return false;
+        return $request->headers->has($this->headerName ?? self::DEFAULT_HEADER_NAME);
     }
 }

--- a/src/lib/Security/JWTTokenCreationRESTRequestMatcher.php
+++ b/src/lib/Security/JWTTokenCreationRESTRequestMatcher.php
@@ -9,14 +9,14 @@ declare(strict_types=1);
 namespace Ibexa\Rest\Security;
 
 use Symfony\Component\HttpFoundation\Request;
-use Symfony\Component\HttpFoundation\RequestMatcher;
+use Symfony\Component\HttpFoundation\RequestMatcherInterface;
 
 /**
  * @internal
  *
  * This class is mandatory for JWT REST calls recognition. It's used within security.firewalls.ibexa_jwt_rest.request_matcher configuration key.
  */
-final class JWTTokenCreationRESTRequestMatcher extends RequestMatcher
+final class JWTTokenCreationRESTRequestMatcher implements RequestMatcherInterface
 {
     public function matches(Request $request): bool
     {
@@ -24,10 +24,6 @@ final class JWTTokenCreationRESTRequestMatcher extends RequestMatcher
             return false;
         }
 
-        if ($request->attributes->get('_route') === 'ibexa.rest.create_token') {
-            return parent::matches($request);
-        }
-
-        return false;
+        return $request->attributes->get('_route') === 'ibexa.rest.create_token';
     }
 }


### PR DESCRIPTION
| :ticket: Issue | IBX-9584  |
|----------------|-----------|

<!-- 
#### Related PRs: 
- https://github.com/ibexa/core/pull/1
-->

#### Description:
Enabled and executed automatic refactoring rules defined for Symfony 6.x.

* [HTTP] Replaced deprecated usage of Symfony\Component\HttpFoundation\RequestMatcher
* [Security] Replaced deprecated usage of Symfony\Component\Security\Core\Security
* [Serializer] Fixed usages of deprecated Symfony\Component\Serializer\Normalizer{ContextAwareDenormalizerInterface, ContextAwareNormalizerInterface};

Additionally added rector job to CI setup to prevent merging up code which is not compatible with Symfony 6+.

#### For QA:
Sanities.

#### Documentation:
N/A

<!-- 
Before you click submit:
    - Test the solution manually
    - Provide automated test coverage
    - Confirm that target branch is set correctly
    - Run PHP CS Fixer for new PHP code (use $ composer fix-cs)
    - Run ESLint and Prettier for new JS/SCSS code (use $ yarn fix)
    - Ask for a review (ping @ibexa/php-dev or @ibexa/javascript-dev depending on the changes) 
--> 
