### PR TITLE
IBX-9058: Swap openapi.summary→openapi.description, name→openapi.summary

### DIFF
--- a/src/lib/Server/Controller/Bookmark/BookmarkCreateController.php
+++ b/src/lib/Server/Controller/Bookmark/BookmarkCreateController.php
@@ -21,10 +21,10 @@ use Symfony\Component\HttpFoundation\Response;
 
 #[Post(
     uriTemplate: '/bookmark/{locationId}',
-    name: 'Create bookmark',
     extraProperties: [OpenApiFactory::OVERRIDE_OPENAPI_RESPONSES => false],
     openapi: new Model\Operation(
-        summary: 'Add given Location to bookmarks of the current user.',
+        summary: 'Create bookmark',
+        description: 'Add given Location to bookmarks of the current user.',
         tags: [
             'Bookmark',
         ],

--- a/src/lib/Server/Controller/Bookmark/BookmarkDeleteController.php
+++ b/src/lib/Server/Controller/Bookmark/BookmarkDeleteController.php
@@ -22,9 +22,9 @@ use Symfony\Component\HttpFoundation\Response;
 
 #[Delete(
     uriTemplate: '/bookmark/{locationId}',
-    name: 'Delete bookmark',
     openapi: new Model\Operation(
-        summary: 'Deletes the given Location from bookmarks of the current user.',
+        summary: 'Delete bookmark',
+        description: 'Deletes the given Location from bookmarks of the current user.',
         tags: [
             'Bookmark',
         ],

--- a/src/lib/Server/Controller/Bookmark/BookmarkIsBookmarkedController.php
+++ b/src/lib/Server/Controller/Bookmark/BookmarkIsBookmarkedController.php
@@ -20,9 +20,9 @@ use Symfony\Component\HttpFoundation\Response;
 
 #[Head(
     uriTemplate: '/bookmark/{locationId}',
-    name: 'Check if Location is bookmarked',
     openapi: new Model\Operation(
-        summary: 'Checks if the given Location is bookmarked by the current user.',
+        summary: 'Check if Location is bookmarked',
+        description: 'Checks if the given Location is bookmarked by the current user.',
         tags: [
             'Bookmark',
         ],

--- a/src/lib/Server/Controller/Bookmark/BookmarkListController.php
+++ b/src/lib/Server/Controller/Bookmark/BookmarkListController.php
@@ -21,10 +21,10 @@ use Symfony\Component\HttpFoundation\Response;
 
 #[Get(
     uriTemplate: '/bookmark',
-    name: 'List of bookmarks',
     extraProperties: [OpenApiFactory::OVERRIDE_OPENAPI_RESPONSES => false],
     openapi: new Model\Operation(
-        summary: 'Lists bookmarked Locations for the current user.',
+        summary: 'List of bookmarks',
+        description: 'Lists bookmarked Locations for the current user.',
         tags: [
             'Bookmark',
         ],

--- a/src/lib/Server/Controller/Content/ContentCreateController.php
+++ b/src/lib/Server/Controller/Content/ContentCreateController.php
@@ -24,10 +24,10 @@ use Symfony\Component\HttpFoundation\Response;
 
 #[Post(
     uriTemplate: '/content/objects',
-    name: 'Create content item',
     extraProperties: [OpenApiFactory::OVERRIDE_OPENAPI_RESPONSES => false],
     openapi: new Model\Operation(
-        summary: 'Creates a draft assigned to the authenticated user. If a different user ID is given in the input, the draft is assigned to the given user but this action requires special permissions for the authenticated user (this is useful for content staging where the transfer process does not have to authenticate with the user who created the content item in the source server). The user needs to publish the content item if it should be visible.',
+        summary: 'Create content item',
+        description: 'Creates a draft assigned to the authenticated user. If a different user ID is given in the input, the draft is assigned to the given user but this action requires special permissions for the authenticated user (this is useful for content staging where the transfer process does not have to authenticate with the user who created the content item in the source server). The user needs to publish the content item if it should be visible.',
         tags: [
             'Objects',
         ],

--- a/src/lib/Server/Controller/Content/ContentCurrentVersionRedirectController.php
+++ b/src/lib/Server/Controller/Content/ContentCurrentVersionRedirectController.php
@@ -15,9 +15,9 @@ use Symfony\Component\HttpFoundation\Response;
 
 #[Get(
     uriTemplate: '/content/objects/{contentId}/currentversion',
-    name: 'Get current version',
     openapi: new Model\Operation(
-        summary: 'Redirects to the current version of the content item.',
+        summary: 'Get current version',
+        description: 'Redirects to the current version of the content item.',
         tags: [
             'Objects',
         ],

--- a/src/lib/Server/Controller/Content/ContentCurrentVersionRelationsRedirectController.php
+++ b/src/lib/Server/Controller/Content/ContentCurrentVersionRelationsRedirectController.php
@@ -16,10 +16,10 @@ use Symfony\Component\HttpFoundation\Response;
 
 #[Get(
     uriTemplate: '/content/objects/{contentId}/relations',
-    name: 'Load Relations of content item',
     extraProperties: [OpenApiFactory::OVERRIDE_OPENAPI_RESPONSES => false],
     openapi: new Model\Operation(
-        summary: 'Redirects to the Relations of the current version.',
+        summary: 'Load Relations of content item',
+        description: 'Redirects to the Relations of the current version.',
         tags: [
             'Objects',
         ],

--- a/src/lib/Server/Controller/Content/ContentDeleteController.php
+++ b/src/lib/Server/Controller/Content/ContentDeleteController.php
@@ -15,9 +15,9 @@ use Symfony\Component\HttpFoundation\Response;
 
 #[Delete(
     uriTemplate: '/content/objects/{contentId}',
-    name: 'Delete Content',
     openapi: new Model\Operation(
-        summary: 'Deletes content item. If content item has multiple Locations, all of them will be deleted via delete a subtree.',
+        summary: 'Delete Content',
+        description: 'Deletes content item. If content item has multiple Locations, all of them will be deleted via delete a subtree.',
         tags: [
             'Objects',
         ],

--- a/src/lib/Server/Controller/Content/ContentDraftCreateFromCurrentVersionController.php
+++ b/src/lib/Server/Controller/Content/ContentDraftCreateFromCurrentVersionController.php
@@ -18,10 +18,10 @@ use Symfony\Component\HttpFoundation\Response;
 
 #[Post(
     uriTemplate: '/content/objects/{contentId}/currentversion',
-    name: 'Create a draft from current version',
     extraProperties: [OpenApiFactory::OVERRIDE_OPENAPI_RESPONSES => false],
     openapi: new Model\Operation(
-        summary: 'The system creates a new draft as a copy of the current version. COPY or POST with header X-HTTP-Method-Override COPY.',
+        summary: 'Create a draft from current version',
+        description: 'The system creates a new draft as a copy of the current version. COPY or POST with header X-HTTP-Method-Override COPY.',
         tags: [
             'Objects',
         ],

--- a/src/lib/Server/Controller/Content/ContentDraftCreateFromVersionController.php
+++ b/src/lib/Server/Controller/Content/ContentDraftCreateFromVersionController.php
@@ -17,10 +17,10 @@ use Symfony\Component\HttpFoundation\Response;
 
 #[Post(
     uriTemplate: '/content/objects/{contentId}/versions/{versionNo}',
-    name: 'Create a draft from a version',
     extraProperties: [OpenApiFactory::OVERRIDE_OPENAPI_RESPONSES => false],
     openapi: new Model\Operation(
-        summary: 'The system creates a new draft as a copy of the given version. COPY or POST with header X-HTTP-Method-Override COPY.',
+        summary: 'Create a draft from a version',
+        description: 'The system creates a new draft as a copy of the given version. COPY or POST with header X-HTTP-Method-Override COPY.',
         tags: [
             'Objects',
         ],

--- a/src/lib/Server/Controller/Content/ContentDraftTranslationDeleteController.php
+++ b/src/lib/Server/Controller/Content/ContentDraftTranslationDeleteController.php
@@ -16,9 +16,9 @@ use Symfony\Component\HttpFoundation\Response;
 
 #[Delete(
     uriTemplate: '/content/objects/{contentId}/versions/{versionNo}/translations/{languageCode}',
-    name: 'Delete translation from version draft',
     openapi: new Model\Operation(
-        summary: 'Removes a translation from a version draft.',
+        summary: 'Delete translation from version draft',
+        description: 'Removes a translation from a version draft.',
         tags: [
             'Objects',
         ],

--- a/src/lib/Server/Controller/Content/ContentHideController.php
+++ b/src/lib/Server/Controller/Content/ContentHideController.php
@@ -16,10 +16,10 @@ use Symfony\Component\HttpFoundation\Response;
 
 #[Post(
     uriTemplate: '/content/objects/{contentId}/hide',
-    name: 'Hide content item',
     extraProperties: [OpenApiFactory::OVERRIDE_OPENAPI_RESPONSES => false],
     openapi: new Model\Operation(
-        summary: 'Makes or keep the content item invisible',
+        summary: 'Hide content item',
+        description: 'Makes or keep the content item invisible',
         tags: [
             'Objects',
         ],

--- a/src/lib/Server/Controller/Content/ContentInVersionLoadController.php
+++ b/src/lib/Server/Controller/Content/ContentInVersionLoadController.php
@@ -20,9 +20,9 @@ use Symfony\Component\HttpFoundation\Response;
 
 #[Get(
     uriTemplate: '/content/objects/{contentId}/versions/{versionNo}',
-    name: 'Load version',
     openapi: new Model\Operation(
-        summary: 'Loads a specific version of a content item. This method returns Fields and relations.',
+        summary: 'Load version',
+        description: 'Loads a specific version of a content item. This method returns Fields and relations.',
         tags: [
             'Objects',
         ],

--- a/src/lib/Server/Controller/Content/ContentLoadByIdController.php
+++ b/src/lib/Server/Controller/Content/ContentLoadByIdController.php
@@ -18,9 +18,9 @@ use Symfony\Component\HttpFoundation\Response;
 
 #[Get(
     uriTemplate: '/content/objects/{contentId}',
-    name: 'Load content',
     openapi: new Model\Operation(
-        summary: 'Loads the content item for the given ID. Depending on the Accept header the current version is embedded (i.e. the current published version or if it does not exist, the draft of the authenticated user).',
+        summary: 'Load content',
+        description: 'Loads the content item for the given ID. Depending on the Accept header the current version is embedded (i.e. the current published version or if it does not exist, the draft of the authenticated user).',
         tags: [
             'Objects',
         ],

--- a/src/lib/Server/Controller/Content/ContentMetadataUpdateController.php
+++ b/src/lib/Server/Controller/Content/ContentMetadataUpdateController.php
@@ -20,10 +20,10 @@ use Symfony\Component\HttpFoundation\Response;
 
 #[Patch(
     uriTemplate: '/content/objects/{contentId}',
-    name: 'Update content',
     extraProperties: [OpenApiFactory::OVERRIDE_OPENAPI_RESPONSES => false],
     openapi: new Model\Operation(
-        summary: 'This method updates the content metadata which is independent from a version. PATCH or POST with header X-HTTP-Method-Override PATCH.',
+        summary: 'Update content',
+        description: 'This method updates the content metadata which is independent from a version. PATCH or POST with header X-HTTP-Method-Override PATCH.',
         tags: [
             'Objects',
         ],

--- a/src/lib/Server/Controller/Content/ContentRedirectController.php
+++ b/src/lib/Server/Controller/Content/ContentRedirectController.php
@@ -18,10 +18,10 @@ use Symfony\Component\HttpFoundation\Response;
 
 #[Get(
     uriTemplate: '/content/objects',
-    name: 'Load content by remote ID',
     extraProperties: [OpenApiFactory::OVERRIDE_OPENAPI_RESPONSES => false],
     openapi: new Model\Operation(
-        summary: 'Loads content item for a given remote ID.',
+        summary: 'Load content by remote ID',
+        description: 'Loads content item for a given remote ID.',
         tags: [
             'Objects',
         ],

--- a/src/lib/Server/Controller/Content/ContentRelationCreateController.php
+++ b/src/lib/Server/Controller/Content/ContentRelationCreateController.php
@@ -23,10 +23,10 @@ use Symfony\Component\HttpFoundation\Response;
 
 #[Post(
     uriTemplate: '/content/objects/{contentId}/versions/{versionNo}/relations',
-    name: 'Create new Relation',
     extraProperties: [OpenApiFactory::OVERRIDE_OPENAPI_RESPONSES => false],
     openapi: new Model\Operation(
-        summary: 'Creates a new Relation of type COMMON for the given draft.',
+        summary: 'Create new Relation',
+        description: 'Creates a new Relation of type COMMON for the given draft.',
         tags: [
             'Objects',
         ],

--- a/src/lib/Server/Controller/Content/ContentRevealController.php
+++ b/src/lib/Server/Controller/Content/ContentRevealController.php
@@ -16,10 +16,10 @@ use Symfony\Component\HttpFoundation\Response;
 
 #[Post(
     uriTemplate: '/content/objects/{contentId}/reveal',
-    name: 'Reveal content item',
     extraProperties: [OpenApiFactory::OVERRIDE_OPENAPI_RESPONSES => false],
     openapi: new Model\Operation(
-        summary: 'Makes or keep the content item visible',
+        summary: 'Reveal content item',
+        description: 'Makes or keep the content item visible',
         tags: [
             'Objects',
         ],

--- a/src/lib/Server/Controller/Content/ContentTranslationDeleteController.php
+++ b/src/lib/Server/Controller/Content/ContentTranslationDeleteController.php
@@ -15,9 +15,9 @@ use Symfony\Component\HttpFoundation\Response;
 
 #[Delete(
     uriTemplate: '/content/objects/{contentId}/translations/{languageCode}',
-    name: 'Delete translation (permanently)',
     openapi: new Model\Operation(
-        summary: 'Permanently deletes a translation from all versions of a content item.',
+        summary: 'Delete translation (permanently)',
+        description: 'Permanently deletes a translation from all versions of a content item.',
         tags: [
             'Objects',
         ],

--- a/src/lib/Server/Controller/Content/ContentVersionDeleteController.php
+++ b/src/lib/Server/Controller/Content/ContentVersionDeleteController.php
@@ -16,9 +16,9 @@ use Symfony\Component\HttpFoundation\Response;
 
 #[Delete(
     uriTemplate: '/content/objects/{contentId}/versions/{versionNo}',
-    name: 'Delete content version',
     openapi: new Model\Operation(
-        summary: 'Deletes the content version.',
+        summary: 'Delete content version',
+        description: 'Deletes the content version.',
         tags: [
             'Objects',
         ],

--- a/src/lib/Server/Controller/Content/ContentVersionRelationDeleteController.php
+++ b/src/lib/Server/Controller/Content/ContentVersionRelationDeleteController.php
@@ -20,9 +20,9 @@ use Symfony\Component\HttpFoundation\Response;
 
 #[Delete(
     uriTemplate: '/content/objects/{contentId}/versions/{versionNo}/relations/{relationId}',
-    name: 'Delete Relation',
     openapi: new Model\Operation(
-        summary: 'Deletes a Relation of the given draft.',
+        summary: 'Delete Relation',
+        description: 'Deletes a Relation of the given draft.',
         tags: [
             'Objects',
         ],

--- a/src/lib/Server/Controller/Content/ContentVersionRelationLoadByIdController.php
+++ b/src/lib/Server/Controller/Content/ContentVersionRelationLoadByIdController.php
@@ -18,9 +18,9 @@ use Symfony\Component\HttpFoundation\Response;
 
 #[Get(
     uriTemplate: '/content/objects/{contentId}/versions/{versionNo}/relations/{relationId}',
-    name: 'Load Relation',
     openapi: new Model\Operation(
-        summary: 'Loads a Relation for the given content item.',
+        summary: 'Load Relation',
+        description: 'Loads a Relation for the given content item.',
         tags: [
             'Objects',
         ],

--- a/src/lib/Server/Controller/Content/ContentVersionUpdateController.php
+++ b/src/lib/Server/Controller/Content/ContentVersionUpdateController.php
@@ -24,10 +24,10 @@ use Symfony\Component\HttpFoundation\Response;
 
 #[Patch(
     uriTemplate: '/content/objects/{contentId}/versions/{versionNo}',
-    name: 'Update version',
     extraProperties: [OpenApiFactory::OVERRIDE_OPENAPI_RESPONSES => false],
     openapi: new Model\Operation(
-        summary: 'A specific draft is updated. PATCH or POST with header X-HTTP-Method-Override PATCH.',
+        summary: 'Update version',
+        description: 'A specific draft is updated. PATCH or POST with header X-HTTP-Method-Override PATCH.',
         tags: [
             'Objects',
         ],

--- a/src/lib/Server/Controller/Content/ContentVersionsListController.php
+++ b/src/lib/Server/Controller/Content/ContentVersionsListController.php
@@ -17,10 +17,10 @@ use Symfony\Component\HttpFoundation\Response;
 
 #[Get(
     uriTemplate: '/content/objects/{contentId}/versions',
-    name: 'List versions',
     extraProperties: [OpenApiFactory::OVERRIDE_OPENAPI_RESPONSES => false],
     openapi: new Model\Operation(
-        summary: 'Returns a list of all versions of the content item. This method does not include fields and relations in the version elements of the response.',
+        summary: 'List versions',
+        description: 'Returns a list of all versions of the content item. This method does not include fields and relations in the version elements of the response.',
         tags: [
             'Objects',
         ],

--- a/src/lib/Server/Controller/Content/ContentVersionsRelationsListController.php
+++ b/src/lib/Server/Controller/Content/ContentVersionsRelationsListController.php
@@ -17,9 +17,9 @@ use Symfony\Component\HttpFoundation\Response;
 
 #[Get(
     uriTemplate: '/content/objects/{contentId}/versions/{versionNo}/relations',
-    name: 'Load Relations of content item version',
     openapi: new Model\Operation(
-        summary: 'Loads the Relations of the given version.',
+        summary: 'Load Relations of content item version',
+        description: 'Loads the Relations of the given version.',
         tags: [
             'Objects',
         ],

--- a/src/lib/Server/Controller/ContentType/ContentTypeCreateController.php
+++ b/src/lib/Server/Controller/ContentType/ContentTypeCreateController.php
@@ -28,10 +28,10 @@ use Symfony\Component\HttpFoundation\Response;
 
 #[Post(
     uriTemplate: '/content/typegroups/{contentTypeGroupId}/types',
-    name: 'Create content type',
     extraProperties: [OpenApiFactory::OVERRIDE_OPENAPI_RESPONSES => false],
     openapi: new Model\Operation(
-        summary: 'Creates a new content type draft in the given content type group.',
+        summary: 'Create content type',
+        description: 'Creates a new content type draft in the given content type group.',
         tags: [
             'Type Groups',
         ],

--- a/src/lib/Server/Controller/ContentType/ContentTypeDeleteController.php
+++ b/src/lib/Server/Controller/ContentType/ContentTypeDeleteController.php
@@ -19,9 +19,9 @@ use Symfony\Component\HttpFoundation\Response;
 
 #[Delete(
     uriTemplate: '/content/types/{contentTypeId}',
-    name: 'Delete content type',
     openapi: new Model\Operation(
-        summary: 'Deletes the provided content type.',
+        summary: 'Delete content type',
+        description: 'Deletes the provided content type.',
         tags: [
             'Type',
         ],

--- a/src/lib/Server/Controller/ContentType/ContentTypeDraftCreateController.php
+++ b/src/lib/Server/Controller/ContentType/ContentTypeDraftCreateController.php
@@ -24,10 +24,10 @@ use Symfony\Component\HttpFoundation\Response;
 
 #[Post(
     uriTemplate: '/content/types/{contentTypeId}',
-    name: 'Create Draft',
     extraProperties: [OpenApiFactory::OVERRIDE_OPENAPI_RESPONSES => false],
     openapi: new Model\Operation(
-        summary: 'Creates a draft and updates it with the given data.',
+        summary: 'Create Draft',
+        description: 'Creates a draft and updates it with the given data.',
         tags: [
             'Type',
         ],

--- a/src/lib/Server/Controller/ContentType/ContentTypeDraftDeleteController.php
+++ b/src/lib/Server/Controller/ContentType/ContentTypeDraftDeleteController.php
@@ -16,9 +16,9 @@ use Symfony\Component\HttpFoundation\Response;
 
 #[Delete(
     uriTemplate: '/content/types/{contentTypeId}/draft',
-    name: 'Delete content type draft',
     openapi: new Model\Operation(
-        summary: 'Deletes the provided content type draft.',
+        summary: 'Delete content type draft',
+        description: 'Deletes the provided content type draft.',
         tags: [
             'Type',
         ],

--- a/src/lib/Server/Controller/ContentType/ContentTypeDraftFieldDefinitionAddController.php
+++ b/src/lib/Server/Controller/ContentType/ContentTypeDraftFieldDefinitionAddController.php
@@ -26,10 +26,10 @@ use Symfony\Component\HttpFoundation\Response;
 
 #[Post(
     uriTemplate: '/content/types/{contentTypeId}/draft/fieldDefinitions',
-    name: 'Add content type Draft Field definition',
     extraProperties: [OpenApiFactory::OVERRIDE_OPENAPI_RESPONSES => false],
     openapi: new Model\Operation(
-        summary: 'Creates a new Field definition for the given content type.',
+        summary: 'Add content type Draft Field definition',
+        description: 'Creates a new Field definition for the given content type.',
         tags: [
             'Type',
         ],

--- a/src/lib/Server/Controller/ContentType/ContentTypeDraftFieldDefinitionDeleteController.php
+++ b/src/lib/Server/Controller/ContentType/ContentTypeDraftFieldDefinitionDeleteController.php
@@ -19,10 +19,10 @@ use Symfony\Component\HttpFoundation\Response;
 
 #[Delete(
     uriTemplate: '/content/types/{contentTypeId}/draft/fieldDefinitions/{fieldDefinitionId}',
-    name: 'Delete content type Draft Field definition',
     extraProperties: [OpenApiFactory::OVERRIDE_OPENAPI_RESPONSES => false],
     openapi: new Model\Operation(
-        summary: 'Deletes the provided Field definition.',
+        summary: 'Delete content type Draft Field definition',
+        description: 'Deletes the provided Field definition.',
         tags: [
             'Type',
         ],

--- a/src/lib/Server/Controller/ContentType/ContentTypeDraftFieldDefinitionListController.php
+++ b/src/lib/Server/Controller/ContentType/ContentTypeDraftFieldDefinitionListController.php
@@ -16,9 +16,9 @@ use Symfony\Component\HttpFoundation\Response;
 
 #[Get(
     uriTemplate: '/content/types/{contentTypeId}/draft/fieldDefinitions',
-    name: 'Get Draft Field definition list',
     openapi: new Model\Operation(
-        summary: 'Returns all Field definitions of the provided content type Draft.',
+        summary: 'Get Draft Field definition list',
+        description: 'Returns all Field definitions of the provided content type Draft.',
         tags: [
             'Type',
         ],

--- a/src/lib/Server/Controller/ContentType/ContentTypeDraftFieldDefinitionLoadByIdController.php
+++ b/src/lib/Server/Controller/ContentType/ContentTypeDraftFieldDefinitionLoadByIdController.php
@@ -18,9 +18,9 @@ use Symfony\Component\HttpFoundation\Response;
 
 #[Get(
     uriTemplate: '/content/types/{contentTypeId}/draft/fieldDefinitions/{fieldDefinitionId}',
-    name: 'Get content type Draft Field definition',
     openapi: new Model\Operation(
-        summary: 'Returns the Field definition by the given ID.',
+        summary: 'Get content type Draft Field definition',
+        description: 'Returns the Field definition by the given ID.',
         tags: [
             'Type',
         ],

--- a/src/lib/Server/Controller/ContentType/ContentTypeDraftFieldDefinitionUpdateController.php
+++ b/src/lib/Server/Controller/ContentType/ContentTypeDraftFieldDefinitionUpdateController.php
@@ -23,10 +23,10 @@ use Symfony\Component\HttpFoundation\Response;
 
 #[Patch(
     uriTemplate: '/content/types/{contentTypeId}/draft/fieldDefinitions/{fieldDefinitionId}',
-    name: 'Update content type Draft Field definition',
     extraProperties: [OpenApiFactory::OVERRIDE_OPENAPI_RESPONSES => false],
     openapi: new Model\Operation(
-        summary: 'Updates the attributes of a Field definition.',
+        summary: 'Update content type Draft Field definition',
+        description: 'Updates the attributes of a Field definition.',
         tags: [
             'Type',
         ],

--- a/src/lib/Server/Controller/ContentType/ContentTypeDraftLoadController.php
+++ b/src/lib/Server/Controller/ContentType/ContentTypeDraftLoadController.php
@@ -16,9 +16,9 @@ use Symfony\Component\HttpFoundation\Response;
 
 #[Get(
     uriTemplate: '/content/types/{contentTypeId}/draft',
-    name: 'Get content type draft',
     openapi: new Model\Operation(
-        summary: 'Returns the draft of the content type with the provided ID.',
+        summary: 'Get content type draft',
+        description: 'Returns the draft of the content type with the provided ID.',
         tags: [
             'Type',
         ],

--- a/src/lib/Server/Controller/ContentType/ContentTypeDraftUpdateController.php
+++ b/src/lib/Server/Controller/ContentType/ContentTypeDraftUpdateController.php
@@ -24,10 +24,10 @@ use Symfony\Component\HttpFoundation\Response;
 
 #[Patch(
     uriTemplate: '/content/types/{contentTypeId}/draft',
-    name: 'Update content type draft',
     extraProperties: [OpenApiFactory::OVERRIDE_OPENAPI_RESPONSES => false],
     openapi: new Model\Operation(
-        summary: 'Updates metadata of a draft. This method does not handle Field definitions. PATCH or POST with header X-HTTP-Method-Override PATCH.',
+        summary: 'Update content type draft',
+        description: 'Updates metadata of a draft. This method does not handle Field definitions. PATCH or POST with header X-HTTP-Method-Override PATCH.',
         tags: [
             'Type',
         ],

--- a/src/lib/Server/Controller/ContentType/ContentTypeFieldDefinitionListController.php
+++ b/src/lib/Server/Controller/ContentType/ContentTypeFieldDefinitionListController.php
@@ -17,9 +17,9 @@ use Symfony\Component\HttpFoundation\Response;
 
 #[Get(
     uriTemplate: '/content/types/{contentTypeId}/fieldDefinitions',
-    name: 'Get Field definition list',
     openapi: new Model\Operation(
-        summary: 'Returns all Field definitions of the provided content type.',
+        summary: 'Get Field definition list',
+        description: 'Returns all Field definitions of the provided content type.',
         tags: [
             'Type',
         ],

--- a/src/lib/Server/Controller/ContentType/ContentTypeFieldDefinitionLoadByIdController.php
+++ b/src/lib/Server/Controller/ContentType/ContentTypeFieldDefinitionLoadByIdController.php
@@ -19,9 +19,9 @@ use Symfony\Component\HttpFoundation\Response;
 
 #[Get(
     uriTemplate: '/content/types/{contentTypeId}/fieldDefinitions/{fieldDefinitionId}',
-    name: 'Get Field definition',
     openapi: new Model\Operation(
-        summary: 'Returns the Field definition by the given ID.',
+        summary: 'Get Field definition',
+        description: 'Returns the Field definition by the given ID.',
         tags: [
             'Type',
         ],

--- a/src/lib/Server/Controller/ContentType/ContentTypeGroupCreateController.php
+++ b/src/lib/Server/Controller/ContentType/ContentTypeGroupCreateController.php
@@ -22,10 +22,10 @@ use Symfony\Component\HttpFoundation\Response;
 
 #[Post(
     uriTemplate: '/content/typegroups',
-    name: 'Create content type group',
     extraProperties: [OpenApiFactory::OVERRIDE_OPENAPI_RESPONSES => false],
     openapi: new Model\Operation(
-        summary: 'Creates a new content type group.',
+        summary: 'Create content type group',
+        description: 'Creates a new content type group.',
         tags: [
             'Type Groups',
         ],

--- a/src/lib/Server/Controller/ContentType/ContentTypeGroupDeleteController.php
+++ b/src/lib/Server/Controller/ContentType/ContentTypeGroupDeleteController.php
@@ -17,9 +17,9 @@ use Symfony\Component\HttpFoundation\Response;
 
 #[Delete(
     uriTemplate: '/content/typegroups/{contentTypeGroupId}',
-    name: 'Delete content type group',
     openapi: new Model\Operation(
-        summary: 'Deletes the provided content type group.',
+        summary: 'Delete content type group',
+        description: 'Deletes the provided content type group.',
         tags: [
             'Type Groups',
         ],

--- a/src/lib/Server/Controller/ContentType/ContentTypeGroupListController.php
+++ b/src/lib/Server/Controller/ContentType/ContentTypeGroupListController.php
@@ -17,9 +17,9 @@ use Symfony\Component\HttpFoundation\Response;
 
 #[Get(
     uriTemplate: '/content/types/{contentTypeId}/groups',
-    name: 'Get groups of content type',
     openapi: new Model\Operation(
-        summary: 'Returns the content type group to which content type belongs to.',
+        summary: 'Get groups of content type',
+        description: 'Returns the content type group to which content type belongs to.',
         tags: [
             'Type',
         ],

--- a/src/lib/Server/Controller/ContentType/ContentTypeGroupLoadByIdController.php
+++ b/src/lib/Server/Controller/ContentType/ContentTypeGroupLoadByIdController.php
@@ -17,9 +17,9 @@ use Symfony\Component\HttpFoundation\Response;
 
 #[Get(
     uriTemplate: '/content/typegroups/{contentTypeGroupId}',
-    name: 'Get content type group',
     openapi: new Model\Operation(
-        summary: 'Returns the content type group with provided ID.',
+        summary: 'Get content type group',
+        description: 'Returns the content type group with provided ID.',
         tags: [
             'Type Groups',
         ],

--- a/src/lib/Server/Controller/ContentType/ContentTypeGroupUpdateController.php
+++ b/src/lib/Server/Controller/ContentType/ContentTypeGroupUpdateController.php
@@ -25,10 +25,10 @@ use Symfony\Component\HttpFoundation\Response;
 
 #[Patch(
     uriTemplate: '/content/typegroups/{contentTypeGroupId}',
-    name: 'Update content type group',
     extraProperties: [OpenApiFactory::OVERRIDE_OPENAPI_RESPONSES => false],
     openapi: new Model\Operation(
-        summary: 'Updates a content type group. PATCH or POST with header X-HTTP-Method-Override PATCH.',
+        summary: 'Update content type group',
+        description: 'Updates a content type group. PATCH or POST with header X-HTTP-Method-Override PATCH.',
         tags: [
             'Type Groups',
         ],

--- a/src/lib/Server/Controller/ContentType/ContentTypeGroupsListController.php
+++ b/src/lib/Server/Controller/ContentType/ContentTypeGroupsListController.php
@@ -18,9 +18,9 @@ use Symfony\Component\HttpFoundation\Response;
 
 #[Get(
     uriTemplate: '/content/typegroups',
-    name: 'Get content type groups',
     openapi: new Model\Operation(
-        summary: 'Returns a list of all content type groups. If an identifier is provided, loads the content type group for this identifier.',
+        summary: 'Get content type groups',
+        description: 'Returns a list of all content type groups. If an identifier is provided, loads the content type group for this identifier.',
         tags: [
             'Type Groups',
         ],

--- a/src/lib/Server/Controller/ContentType/ContentTypeLinkToGroupController.php
+++ b/src/lib/Server/Controller/ContentType/ContentTypeLinkToGroupController.php
@@ -21,10 +21,10 @@ use Symfony\Component\HttpFoundation\Response;
 
 #[Post(
     uriTemplate: '/content/types/{contentTypeId}/groups',
-    name: 'Link group to content type',
     extraProperties: [OpenApiFactory::OVERRIDE_OPENAPI_RESPONSES => false],
     openapi: new Model\Operation(
-        summary: 'Links a content type group to the content type and returns the updated group list.',
+        summary: 'Link group to content type',
+        description: 'Links a content type group to the content type and returns the updated group list.',
         tags: [
             'Type',
         ],

--- a/src/lib/Server/Controller/ContentType/ContentTypeListController.php
+++ b/src/lib/Server/Controller/ContentType/ContentTypeListController.php
@@ -22,10 +22,10 @@ use Symfony\Component\HttpFoundation\Response;
 
 #[Get(
     uriTemplate: '/content/types',
-    name: 'List content types',
     extraProperties: [OpenApiFactory::OVERRIDE_OPENAPI_RESPONSES => false],
     openapi: new Model\Operation(
-        summary: 'Returns a list of content types.',
+        summary: 'List content types',
+        description: 'Returns a list of content types.',
         tags: [
             'Type',
         ],

--- a/src/lib/Server/Controller/ContentType/ContentTypeListForGroupController.php
+++ b/src/lib/Server/Controller/ContentType/ContentTypeListForGroupController.php
@@ -19,10 +19,10 @@ use Symfony\Component\HttpFoundation\Response;
 
 #[Get(
     uriTemplate: '/content/typegroups/{contentTypeGroupId}/types',
-    name: 'List content types for group',
     extraProperties: [OpenApiFactory::OVERRIDE_OPENAPI_RESPONSES => false],
     openapi: new Model\Operation(
-        summary: 'Returns a list of content types in the provided group.',
+        summary: 'List content types for group',
+        description: 'Returns a list of content types in the provided group.',
         tags: [
             'Type Groups',
         ],

--- a/src/lib/Server/Controller/ContentType/ContentTypeLoadByIdController.php
+++ b/src/lib/Server/Controller/ContentType/ContentTypeLoadByIdController.php
@@ -17,9 +17,9 @@ use Symfony\Component\HttpFoundation\Response;
 
 #[Get(
     uriTemplate: '/content/types/{contentTypeId}',
-    name: 'Get content type',
     openapi: new Model\Operation(
-        summary: 'Returns the content type with the provided ID.',
+        summary: 'Get content type',
+        description: 'Returns the content type with the provided ID.',
         tags: [
             'Type',
         ],

--- a/src/lib/Server/Controller/ContentType/ContentTypeUnlinkFromGroupController.php
+++ b/src/lib/Server/Controller/ContentType/ContentTypeUnlinkFromGroupController.php
@@ -18,9 +18,9 @@ use Symfony\Component\HttpFoundation\Response;
 
 #[Delete(
     uriTemplate: '/content/types/{contentTypeId}/groups/{id}',
-    name: 'Unlink group from content type',
     openapi: new Model\Operation(
-        summary: 'Removes the given group from the content type and returns the updated group list.',
+        summary: 'Unlink group from content type',
+        description: 'Removes the given group from the content type and returns the updated group list.',
         tags: [
             'Type',
         ],

--- a/src/lib/Server/Controller/JWT.php
+++ b/src/lib/Server/Controller/JWT.php
@@ -17,10 +17,10 @@ use Symfony\Component\HttpFoundation\Response;
 
 #[Post(
     uriTemplate: '/user/token/jwt',
-    name: 'Create JWT token',
     extraProperties: [OpenApiFactory::OVERRIDE_OPENAPI_RESPONSES => false],
     openapi: new Model\Operation(
-        summary: 'Creates JWT authentication token.',
+        summary: 'Create JWT token',
+        description: 'Creates JWT authentication token.',
         tags: [
             'User Token',
         ],

--- a/src/lib/Server/Controller/Language/LanguageListController.php
+++ b/src/lib/Server/Controller/Language/LanguageListController.php
@@ -19,10 +19,10 @@ use Traversable;
 
 #[Get(
     uriTemplate: '/languages',
-    name: 'Language list',
     extraProperties: [OpenApiFactory::OVERRIDE_OPENAPI_RESPONSES => false],
     openapi: new Model\Operation(
-        summary: 'Lists languages',
+        summary: 'Language list',
+        description: 'Lists languages',
         tags: [
             'Language',
         ],

--- a/src/lib/Server/Controller/Language/LanguageLoadByIdController.php
+++ b/src/lib/Server/Controller/Language/LanguageLoadByIdController.php
@@ -18,9 +18,9 @@ use Symfony\Component\HttpFoundation\Response;
 
 #[Get(
     uriTemplate: '/languages/{code}',
-    name: 'Get language',
     extraProperties: [OpenApiFactory::OVERRIDE_OPENAPI_RESPONSES => false],
     openapi: new Model\Operation(
+        summary: 'Get language',
         tags: [
             'Language',
         ],

--- a/src/lib/Server/Controller/Location/LocationChildrenListController.php
+++ b/src/lib/Server/Controller/Location/LocationChildrenListController.php
@@ -15,9 +15,9 @@ use Symfony\Component\HttpFoundation\Response;
 
 #[Get(
     uriTemplate: '/content/locations/{path}/children',
-    name: 'Get child Locations.',
     openapi: new Model\Operation(
-        summary: 'Loads all child Locations for the given parent Location.',
+        summary: 'Get child Locations.',
+        description: 'Loads all child Locations for the given parent Location.',
         tags: [
             'Location',
         ],

--- a/src/lib/Server/Controller/Location/LocationCreateController.php
+++ b/src/lib/Server/Controller/Location/LocationCreateController.php
@@ -20,10 +20,10 @@ use Symfony\Component\HttpFoundation\Response;
 
 #[Post(
     uriTemplate: '/content/objects/{contentId}/locations',
-    name: 'Create new Location for content item',
     extraProperties: [OpenApiFactory::OVERRIDE_OPENAPI_RESPONSES => false],
     openapi: new Model\Operation(
-        summary: 'Creates a new Location for the given content item.',
+        summary: 'Create new Location for content item',
+        description: 'Creates a new Location for the given content item.',
         tags: [
             'Objects',
         ],

--- a/src/lib/Server/Controller/Location/LocationForContentListController.php
+++ b/src/lib/Server/Controller/Location/LocationForContentListController.php
@@ -15,9 +15,9 @@ use Symfony\Component\HttpFoundation\Response;
 
 #[Get(
     uriTemplate: '/content/objects/{contentId}/locations',
-    name: 'Get Locations for content item',
     openapi: new Model\Operation(
-        summary: 'Loads all Locations for the given content item.',
+        summary: 'Get Locations for content item',
+        description: 'Loads all Locations for the given content item.',
         tags: [
             'Objects',
         ],

--- a/src/lib/Server/Controller/Location/LocationLoadByPathController.php
+++ b/src/lib/Server/Controller/Location/LocationLoadByPathController.php
@@ -15,9 +15,9 @@ use Symfony\Component\HttpFoundation\Response;
 
 #[Get(
     uriTemplate: '/content/locations/{path}',
-    name: 'Load Location',
     openapi: new Model\Operation(
-        summary: 'Loads the Location for the given path e.g. \'/content/locations/1/2/61\'.',
+        summary: 'Load Location',
+        description: 'Loads the Location for the given path e.g. \'/content/locations/1/2/61\'.',
         tags: [
             'Location',
         ],

--- a/src/lib/Server/Controller/Location/LocationRedirectController.php
+++ b/src/lib/Server/Controller/Location/LocationRedirectController.php
@@ -16,9 +16,9 @@ use Symfony\Component\HttpFoundation\Response;
 
 #[Get(
     uriTemplate: '/content/locations',
-    name: 'Load Locations by id/remoteId/urlAlias',
     openapi: new Model\Operation(
-        summary: 'Loads the Location for a given ID (x), remote ID or URL alias.',
+        summary: 'Load Locations by id/remoteId/urlAlias',
+        description: 'Loads the Location for a given ID (x), remote ID or URL alias.',
         tags: [
             'Location',
         ],

--- a/src/lib/Server/Controller/Location/LocationSubtreeDeleteController.php
+++ b/src/lib/Server/Controller/Location/LocationSubtreeDeleteController.php
@@ -14,9 +14,9 @@ use Symfony\Component\HttpFoundation\Response;
 
 #[Delete(
     uriTemplate: '/content/locations/{path}',
-    name: 'Delete subtree',
     openapi: new Model\Operation(
-        summary: 'Deletes the complete subtree for the given path. Every content item which does not have any other Location is deleted. Otherwise the deleted Location is removed from the content item. The children are recursively deleted.',
+        summary: 'Delete subtree',
+        description: 'Deletes the complete subtree for the given path. Every content item which does not have any other Location is deleted. Otherwise the deleted Location is removed from the content item. The children are recursively deleted.',
         tags: [
             'Location',
         ],

--- a/src/lib/Server/Controller/Location/LocationUpdateController.php
+++ b/src/lib/Server/Controller/Location/LocationUpdateController.php
@@ -17,10 +17,10 @@ use Symfony\Component\HttpFoundation\Response;
 
 #[Patch(
     uriTemplate: '/content/locations/{path}',
-    name: 'Update Location',
     extraProperties: [OpenApiFactory::OVERRIDE_OPENAPI_RESPONSES => false],
     openapi: new Model\Operation(
-        summary: 'Updates the Location. This method can also be used to hide/reveal a Location via the hidden field in the LocationUpdate. PATCH or POST with header X-HTTP-Method-Override PATCH.',
+        summary: 'Update Location',
+        description: 'Updates the Location. This method can also be used to hide/reveal a Location via the hidden field in the LocationUpdate. PATCH or POST with header X-HTTP-Method-Override PATCH.',
         tags: [
             'Location',
         ],

--- a/src/lib/Server/Controller/ObjectState/ObjectStateCreateController.php
+++ b/src/lib/Server/Controller/ObjectState/ObjectStateCreateController.php
@@ -24,10 +24,10 @@ use Symfony\Component\HttpFoundation\Response;
 
 #[Post(
     uriTemplate: '/content/objectstategroups/{objectStateGroupId}/objectstates',
-    name: 'Create Object state',
     extraProperties: [OpenApiFactory::OVERRIDE_OPENAPI_RESPONSES => false],
     openapi: new Model\Operation(
-        summary: 'Creates a new Object state.',
+        summary: 'Create Object state',
+        description: 'Creates a new Object state.',
         tags: [
             'Object State Groups',
         ],

--- a/src/lib/Server/Controller/ObjectState/ObjectStateDeleteController.php
+++ b/src/lib/Server/Controller/ObjectState/ObjectStateDeleteController.php
@@ -17,9 +17,9 @@ use Symfony\Component\HttpFoundation\Response;
 
 #[Delete(
     uriTemplate: '/content/objectstategroups/{objectStateGroupId}/objectstates/{objectStateId}',
-    name: 'Delete Object state',
     openapi: new Model\Operation(
-        summary: 'Deletes provided Object state.',
+        summary: 'Delete Object state',
+        description: 'Deletes provided Object state.',
         tags: [
             'Object State Groups',
         ],

--- a/src/lib/Server/Controller/ObjectState/ObjectStateGroupCreateController.php
+++ b/src/lib/Server/Controller/ObjectState/ObjectStateGroupCreateController.php
@@ -23,10 +23,10 @@ use Symfony\Component\HttpFoundation\Response;
 
 #[Post(
     uriTemplate: '/content/objectstategroups',
-    name: 'Create Object state group',
     extraProperties: [OpenApiFactory::OVERRIDE_OPENAPI_RESPONSES => false],
     openapi: new Model\Operation(
-        summary: 'Creates a new Object state group.',
+        summary: 'Create Object state group',
+        description: 'Creates a new Object state group.',
         tags: [
             'Object State Groups',
         ],

--- a/src/lib/Server/Controller/ObjectState/ObjectStateGroupDeleteController.php
+++ b/src/lib/Server/Controller/ObjectState/ObjectStateGroupDeleteController.php
@@ -17,9 +17,9 @@ use Symfony\Component\HttpFoundation\Response;
 
 #[Delete(
     uriTemplate: '/content/objectstategroups/{objectStateGroupId}',
-    name: 'Delete Object state group',
     openapi: new Model\Operation(
-        summary: 'Deletes the given Object state group including Object states.',
+        summary: 'Delete Object state group',
+        description: 'Deletes the given Object state group including Object states.',
         tags: [
             'Object State Groups',
         ],

--- a/src/lib/Server/Controller/ObjectState/ObjectStateGroupListController.php
+++ b/src/lib/Server/Controller/ObjectState/ObjectStateGroupListController.php
@@ -19,10 +19,10 @@ use Symfony\Component\HttpFoundation\Response;
 
 #[Get(
     uriTemplate: '/content/objectstategroups',
-    name: 'List Object state groups',
     extraProperties: [OpenApiFactory::OVERRIDE_OPENAPI_RESPONSES => false],
     openapi: new Model\Operation(
-        summary: 'Returns a list of all Object state groups.',
+        summary: 'List Object state groups',
+        description: 'Returns a list of all Object state groups.',
         tags: [
             'Object State Groups',
         ],

--- a/src/lib/Server/Controller/ObjectState/ObjectStateGroupLoadByIdController.php
+++ b/src/lib/Server/Controller/ObjectState/ObjectStateGroupLoadByIdController.php
@@ -17,9 +17,9 @@ use Symfony\Component\HttpFoundation\Response;
 
 #[Get(
     uriTemplate: '/content/objectstategroups/{objectStateGroupId}',
-    name: 'Get Object state group',
     openapi: new Model\Operation(
-        summary: 'Returns the Object state group with the provided ID.',
+        summary: 'Get Object state group',
+        description: 'Returns the Object state group with the provided ID.',
         tags: [
             'Object State Groups',
         ],

--- a/src/lib/Server/Controller/ObjectState/ObjectStateGroupUpdateController.php
+++ b/src/lib/Server/Controller/ObjectState/ObjectStateGroupUpdateController.php
@@ -22,10 +22,10 @@ use Symfony\Component\HttpFoundation\Response;
 
 #[Patch(
     uriTemplate: '/content/objectstategroups/{objectStateGroupId}',
-    name: 'Update Object state group',
     extraProperties: [OpenApiFactory::OVERRIDE_OPENAPI_RESPONSES => false],
     openapi: new Model\Operation(
-        summary: 'Updates an Object state group. PATCH or POST with header X-HTTP-Method-Override PATCH.',
+        summary: 'Update Object state group',
+        description: 'Updates an Object state group. PATCH or POST with header X-HTTP-Method-Override PATCH.',
         tags: [
             'Object State Groups',
         ],

--- a/src/lib/Server/Controller/ObjectState/ObjectStateListController.php
+++ b/src/lib/Server/Controller/ObjectState/ObjectStateListController.php
@@ -19,10 +19,10 @@ use Symfony\Component\HttpFoundation\Response;
 
 #[Get(
     uriTemplate: '/content/objectstategroups/{objectStateGroupId}/objectstates',
-    name: 'List Object states',
     extraProperties: [OpenApiFactory::OVERRIDE_OPENAPI_RESPONSES => false],
     openapi: new Model\Operation(
-        summary: 'Returns a list of all Object states of the given group.',
+        summary: 'List Object states',
+        description: 'Returns a list of all Object states of the given group.',
         tags: [
             'Object State Groups',
         ],

--- a/src/lib/Server/Controller/ObjectState/ObjectStateLoadByIdController.php
+++ b/src/lib/Server/Controller/ObjectState/ObjectStateLoadByIdController.php
@@ -18,9 +18,9 @@ use Symfony\Component\HttpFoundation\Response;
 
 #[Get(
     uriTemplate: '/content/objectstategroups/{objectStateGroupId}/objectstates/{objectStateId}',
-    name: 'Get Object state',
     openapi: new Model\Operation(
-        summary: 'Returns the Object state.',
+        summary: 'Get Object state',
+        description: 'Returns the Object state.',
         tags: [
             'Object State Groups',
         ],

--- a/src/lib/Server/Controller/ObjectState/ObjectStateUpdateController.php
+++ b/src/lib/Server/Controller/ObjectState/ObjectStateUpdateController.php
@@ -23,10 +23,10 @@ use Symfony\Component\HttpFoundation\Response;
 
 #[Patch(
     uriTemplate: '/content/objectstategroups/{objectStateGroupId}/objectstates/{objectStateId}',
-    name: 'Update Object state',
     extraProperties: [OpenApiFactory::OVERRIDE_OPENAPI_RESPONSES => false],
     openapi: new Model\Operation(
-        summary: 'Updates an Object state. PATCH or POST with header X-HTTP-Method-Override PATCH.',
+        summary: 'Update Object state',
+        description: 'Updates an Object state. PATCH or POST with header X-HTTP-Method-Override PATCH.',
         tags: [
             'Object State Groups',
         ],

--- a/src/lib/Server/Controller/ObjectState/ObjectStatesForContentListController.php
+++ b/src/lib/Server/Controller/ObjectState/ObjectStatesForContentListController.php
@@ -20,10 +20,10 @@ use Symfony\Component\HttpFoundation\Response;
 
 #[Get(
     uriTemplate: '/content/objects/{contentId}/objectstates',
-    name: 'Get Object states of content item',
     extraProperties: [OpenApiFactory::OVERRIDE_OPENAPI_RESPONSES => false],
     openapi: new Model\Operation(
-        summary: 'Returns the Object states of a content item',
+        summary: 'Get Object states of content item',
+        description: 'Returns the Object states of a content item',
         tags: [
             'Objects',
         ],

--- a/src/lib/Server/Controller/ObjectState/ObjectStatesForContentUpdateController.php
+++ b/src/lib/Server/Controller/ObjectState/ObjectStatesForContentUpdateController.php
@@ -22,10 +22,10 @@ use Symfony\Component\HttpFoundation\Response;
 
 #[Patch(
     uriTemplate: '/content/objects/{contentId}/objectstates',
-    name: 'Set Object states of content item',
     extraProperties: [OpenApiFactory::OVERRIDE_OPENAPI_RESPONSES => false],
     openapi: new Model\Operation(
-        summary: 'Updates Object states of a content item. An Object state in the input overrides the state of the Object state group. PATCH or POST with header X-HTTP-Method-Override PATCH.',
+        summary: 'Set Object states of content item',
+        description: 'Updates Object states of a content item. An Object state in the input overrides the state of the Object state group. PATCH or POST with header X-HTTP-Method-Override PATCH.',
         tags: [
             'Objects',
         ],

--- a/src/lib/Server/Controller/Role/RoleAssignToUserController.php
+++ b/src/lib/Server/Controller/Role/RoleAssignToUserController.php
@@ -19,10 +19,10 @@ use Symfony\Component\HttpFoundation\Response;
 
 #[Post(
     uriTemplate: '/user/users/{userId}/roles',
-    name: 'Assign Role to User',
     extraProperties: [OpenApiFactory::OVERRIDE_OPENAPI_RESPONSES => false],
     openapi: new Model\Operation(
-        summary: 'Assigns a Role to a user.',
+        summary: 'Assign Role to User',
+        description: 'Assigns a Role to a user.',
         tags: [
             'User',
         ],

--- a/src/lib/Server/Controller/Role/RoleAssignToUserGroupController.php
+++ b/src/lib/Server/Controller/Role/RoleAssignToUserGroupController.php
@@ -19,10 +19,10 @@ use Symfony\Component\HttpFoundation\Response;
 
 #[Post(
     uriTemplate: '/user/groups/{path}/roles',
-    name: 'Assign Role to User Group',
     extraProperties: [OpenApiFactory::OVERRIDE_OPENAPI_RESPONSES => false],
     openapi: new Model\Operation(
-        summary: 'Assigns a Role to a User Group.',
+        summary: 'Assign Role to User Group',
+        description: 'Assigns a Role to a User Group.',
         tags: [
             'User Group',
         ],

--- a/src/lib/Server/Controller/Role/RoleAssignmentForUserGroupListController.php
+++ b/src/lib/Server/Controller/Role/RoleAssignmentForUserGroupListController.php
@@ -15,10 +15,10 @@ use Symfony\Component\HttpFoundation\Response;
 
 #[Get(
     uriTemplate: '/user/groups/{path}/roles',
-    name: 'Load Roles for User Group',
     extraProperties: [OpenApiFactory::OVERRIDE_OPENAPI_RESPONSES => false],
     openapi: new Model\Operation(
-        summary: 'Returns a list of all Roles assigned to the given User Group.',
+        summary: 'Load Roles for User Group',
+        description: 'Returns a list of all Roles assigned to the given User Group.',
         tags: [
             'User Group',
         ],

--- a/src/lib/Server/Controller/Role/RoleAssignmentForUserGroupLoadByIdController.php
+++ b/src/lib/Server/Controller/Role/RoleAssignmentForUserGroupLoadByIdController.php
@@ -17,10 +17,10 @@ use Symfony\Component\HttpFoundation\Response;
 
 #[Get(
     uriTemplate: '/user/groups/{path}/roles/{roleId}',
-    name: 'Load User Group Role Assignment',
     extraProperties: [OpenApiFactory::OVERRIDE_OPENAPI_RESPONSES => false],
     openapi: new Model\Operation(
-        summary: 'Returns a Role assignment of the given User Group.',
+        summary: 'Load User Group Role Assignment',
+        description: 'Returns a Role assignment of the given User Group.',
         tags: [
             'User Group',
         ],

--- a/src/lib/Server/Controller/Role/RoleAssignmentForUserListController.php
+++ b/src/lib/Server/Controller/Role/RoleAssignmentForUserListController.php
@@ -15,10 +15,10 @@ use Symfony\Component\HttpFoundation\Response;
 
 #[Get(
     uriTemplate: '/user/users/{userId}/roles',
-    name: 'Load Roles for User',
     extraProperties: [OpenApiFactory::OVERRIDE_OPENAPI_RESPONSES => false],
     openapi: new Model\Operation(
-        summary: 'Returns a list of all Roles assigned to the given User.',
+        summary: 'Load Roles for User',
+        description: 'Returns a list of all Roles assigned to the given User.',
         tags: [
             'User',
         ],

--- a/src/lib/Server/Controller/Role/RoleAssignmentForUserLoadByIdController.php
+++ b/src/lib/Server/Controller/Role/RoleAssignmentForUserLoadByIdController.php
@@ -17,10 +17,10 @@ use Symfony\Component\HttpFoundation\Response;
 
 #[Get(
     uriTemplate: '/user/users/{userId}/roles/{roleId}',
-    name: 'Load User Role Assignment',
     extraProperties: [OpenApiFactory::OVERRIDE_OPENAPI_RESPONSES => false],
     openapi: new Model\Operation(
-        summary: 'Returns a Role assignment to the given User.',
+        summary: 'Load User Role Assignment',
+        description: 'Returns a Role assignment to the given User.',
         tags: [
             'User',
         ],

--- a/src/lib/Server/Controller/Role/RoleCreateController.php
+++ b/src/lib/Server/Controller/Role/RoleCreateController.php
@@ -25,10 +25,10 @@ use Symfony\Component\HttpFoundation\Response;
 
 #[Post(
     uriTemplate: '/user/roles',
-    name: 'Create Role or Role draft',
     extraProperties: [OpenApiFactory::OVERRIDE_OPENAPI_RESPONSES => false],
     openapi: new Model\Operation(
-        summary: 'Creates a new Role or Role draft.',
+        summary: 'Create Role or Role draft',
+        description: 'Creates a new Role or Role draft.',
         tags: [
             'User Role',
         ],

--- a/src/lib/Server/Controller/Role/RoleDeleteController.php
+++ b/src/lib/Server/Controller/Role/RoleDeleteController.php
@@ -15,10 +15,10 @@ use Symfony\Component\HttpFoundation\Response;
 
 #[Delete(
     uriTemplate: '/user/roles/{id}',
-    name: 'Delete Role',
     extraProperties: [OpenApiFactory::OVERRIDE_OPENAPI_RESPONSES => false],
     openapi: new Model\Operation(
-        summary: 'The given Role and all assignments to Users or User Groups are deleted.',
+        summary: 'Delete Role',
+        description: 'The given Role and all assignments to Users or User Groups are deleted.',
         tags: [
             'User Role',
         ],

--- a/src/lib/Server/Controller/Role/RoleDraftCreateController.php
+++ b/src/lib/Server/Controller/Role/RoleDraftCreateController.php
@@ -22,10 +22,10 @@ use Symfony\Component\HttpFoundation\Response;
 
 #[Post(
     uriTemplate: '/user/roles/{id}',
-    name: 'Create Role Draft',
     extraProperties: [OpenApiFactory::OVERRIDE_OPENAPI_RESPONSES => false],
     openapi: new Model\Operation(
-        summary: 'Creates a new Role draft from an existing Role.',
+        summary: 'Create Role Draft',
+        description: 'Creates a new Role draft from an existing Role.',
         tags: [
             'User Role',
         ],

--- a/src/lib/Server/Controller/Role/RoleDraftDeleteController.php
+++ b/src/lib/Server/Controller/Role/RoleDraftDeleteController.php
@@ -15,10 +15,10 @@ use Symfony\Component\HttpFoundation\Response;
 
 #[Delete(
     uriTemplate: '/user/roles/{id}/draft',
-    name: 'Delete Role draft',
     extraProperties: [OpenApiFactory::OVERRIDE_OPENAPI_RESPONSES => false],
     openapi: new Model\Operation(
-        summary: 'The given Role draft is deleted.',
+        summary: 'Delete Role draft',
+        description: 'The given Role draft is deleted.',
         tags: [
             'User Role',
         ],

--- a/src/lib/Server/Controller/Role/RoleDraftLoadByRoleIdController.php
+++ b/src/lib/Server/Controller/Role/RoleDraftLoadByRoleIdController.php
@@ -14,9 +14,9 @@ use Symfony\Component\HttpFoundation\Response;
 
 #[Get(
     uriTemplate: '/user/roles/{id}/draft',
-    name: 'Load Role draft',
     openapi: new Model\Operation(
-        summary: 'Loads a Role draft by original Role ID.',
+        summary: 'Load Role draft',
+        description: 'Loads a Role draft by original Role ID.',
         tags: [
             'User Role',
         ],

--- a/src/lib/Server/Controller/Role/RoleDraftUpdateController.php
+++ b/src/lib/Server/Controller/Role/RoleDraftUpdateController.php
@@ -17,10 +17,10 @@ use Symfony\Component\HttpFoundation\Response;
 
 #[Patch(
     uriTemplate: '/user/roles/{id}/draft',
-    name: 'Update Role draft',
     extraProperties: [OpenApiFactory::OVERRIDE_OPENAPI_RESPONSES => false],
     openapi: new Model\Operation(
-        summary: 'Updates a Role draft. PATCH or POST with header X-HTTP-Method-Override PATCH.',
+        summary: 'Update Role draft',
+        description: 'Updates a Role draft. PATCH or POST with header X-HTTP-Method-Override PATCH.',
         tags: [
             'User Role',
         ],

--- a/src/lib/Server/Controller/Role/RoleListController.php
+++ b/src/lib/Server/Controller/Role/RoleListController.php
@@ -17,10 +17,10 @@ use Symfony\Component\HttpFoundation\Response;
 
 #[Get(
     uriTemplate: '/user/roles',
-    name: 'Load Roles',
     extraProperties: [OpenApiFactory::OVERRIDE_OPENAPI_RESPONSES => false],
     openapi: new Model\Operation(
-        summary: 'Returns a list of all Roles.',
+        summary: 'Load Roles',
+        description: 'Returns a list of all Roles.',
         tags: [
             'User Role',
         ],

--- a/src/lib/Server/Controller/Role/RoleLoadByIdController.php
+++ b/src/lib/Server/Controller/Role/RoleLoadByIdController.php
@@ -13,9 +13,9 @@ use Symfony\Component\HttpFoundation\Response;
 
 #[Get(
     uriTemplate: '/user/roles/{id}',
-    name: 'Load Role',
     openapi: new Model\Operation(
-        summary: 'Loads a Role for the given ID.',
+        summary: 'Load Role',
+        description: 'Loads a Role for the given ID.',
         tags: [
             'User Role',
         ],

--- a/src/lib/Server/Controller/Role/RolePoliciesForUserListController.php
+++ b/src/lib/Server/Controller/Role/RolePoliciesForUserListController.php
@@ -16,10 +16,10 @@ use Symfony\Component\HttpFoundation\Response;
 
 #[Get(
     uriTemplate: '/user/policies',
-    name: 'List Policies for User',
     extraProperties: [OpenApiFactory::OVERRIDE_OPENAPI_RESPONSES => false],
     openapi: new Model\Operation(
-        summary: 'Search all Policies which are applied to a given User.',
+        summary: 'List Policies for User',
+        description: 'Search all Policies which are applied to a given User.',
         tags: [
             'User Policy',
         ],

--- a/src/lib/Server/Controller/Role/RolePolicyCreateController.php
+++ b/src/lib/Server/Controller/Role/RolePolicyCreateController.php
@@ -20,10 +20,10 @@ use Symfony\Component\HttpFoundation\Response;
 
 #[Post(
     uriTemplate: '/user/roles/{id}/policies',
-    name: 'Create Policy',
     extraProperties: [OpenApiFactory::OVERRIDE_OPENAPI_RESPONSES => false],
     openapi: new Model\Operation(
-        summary: 'Creates a Policy',
+        summary: 'Create Policy',
+        description: 'Creates a Policy',
         tags: [
             'User Role',
         ],

--- a/src/lib/Server/Controller/Role/RolePolicyDeleteAllFromRoleController.php
+++ b/src/lib/Server/Controller/Role/RolePolicyDeleteAllFromRoleController.php
@@ -15,10 +15,10 @@ use Symfony\Component\HttpFoundation\Response;
 
 #[Delete(
     uriTemplate: '/user/roles/{id}/policies',
-    name: 'Delete Policies',
     extraProperties: [OpenApiFactory::OVERRIDE_OPENAPI_RESPONSES => false],
     openapi: new Model\Operation(
-        summary: 'All Policies of the given Role are deleted.',
+        summary: 'Delete Policies',
+        description: 'All Policies of the given Role are deleted.',
         tags: [
             'User Role',
         ],

--- a/src/lib/Server/Controller/Role/RolePolicyDeleteController.php
+++ b/src/lib/Server/Controller/Role/RolePolicyDeleteController.php
@@ -18,9 +18,9 @@ use Symfony\Component\HttpFoundation\Response;
 
 #[Delete(
     uriTemplate: '/user/roles/{roleId}/policies/{policyId}',
-    name: 'Delete Policy',
     openapi: new Model\Operation(
-        summary: 'Deletes given Policy.',
+        summary: 'Delete Policy',
+        description: 'Deletes given Policy.',
         tags: [
             'User Role',
         ],

--- a/src/lib/Server/Controller/Role/RolePolicyListController.php
+++ b/src/lib/Server/Controller/Role/RolePolicyListController.php
@@ -15,9 +15,9 @@ use Symfony\Component\HttpFoundation\Response;
 
 #[Get(
     uriTemplate: '/user/roles/{id}/policies',
-    name: 'Load Policies',
     openapi: new Model\Operation(
-        summary: 'Loads Policies for the given Role.',
+        summary: 'Load Policies',
+        description: 'Loads Policies for the given Role.',
         tags: [
             'User Role',
         ],

--- a/src/lib/Server/Controller/Role/RolePolicyLoadByIdController.php
+++ b/src/lib/Server/Controller/Role/RolePolicyLoadByIdController.php
@@ -15,9 +15,9 @@ use Symfony\Component\HttpFoundation\Response;
 
 #[Get(
     uriTemplate: '/user/roles/{roleId}/policies/{policyId}',
-    name: 'Load Policy',
     openapi: new Model\Operation(
-        summary: 'Loads a Policy for the given module and function.',
+        summary: 'Load Policy',
+        description: 'Loads a Policy for the given module and function.',
         tags: [
             'User Role',
         ],

--- a/src/lib/Server/Controller/Role/RolePolicyUpdateController.php
+++ b/src/lib/Server/Controller/Role/RolePolicyUpdateController.php
@@ -21,10 +21,10 @@ use Symfony\Component\HttpFoundation\Response;
 
 #[Patch(
     uriTemplate: '/user/roles/{roleId}/policies/{policyId}',
-    name: 'Update Policy',
     extraProperties: [OpenApiFactory::OVERRIDE_OPENAPI_RESPONSES => false],
     openapi: new Model\Operation(
-        summary: 'Updates a Policy. PATCH or POST with header X-HTTP-Method-Override PATCH.',
+        summary: 'Update Policy',
+        description: 'Updates a Policy. PATCH or POST with header X-HTTP-Method-Override PATCH.',
         tags: [
             'User Role',
         ],

--- a/src/lib/Server/Controller/Role/RoleUnassignFromUserController.php
+++ b/src/lib/Server/Controller/Role/RoleUnassignFromUserController.php
@@ -15,10 +15,10 @@ use Symfony\Component\HttpFoundation\Response;
 
 #[Delete(
     uriTemplate: '/user/users/{userId}/roles/{roleId}',
-    name: 'Unassign Role from User',
     extraProperties: [OpenApiFactory::OVERRIDE_OPENAPI_RESPONSES => false],
     openapi: new Model\Operation(
-        summary: 'The given Role is removed from the user.',
+        summary: 'Unassign Role from User',
+        description: 'The given Role is removed from the user.',
         tags: [
             'User',
         ],

--- a/src/lib/Server/Controller/Role/RoleUnassignFromUserGroupController.php
+++ b/src/lib/Server/Controller/Role/RoleUnassignFromUserGroupController.php
@@ -15,10 +15,10 @@ use Symfony\Component\HttpFoundation\Response;
 
 #[Delete(
     uriTemplate: '/user/groups/{path}/roles/{roleId}',
-    name: 'Unassign Role from User Group',
     extraProperties: [OpenApiFactory::OVERRIDE_OPENAPI_RESPONSES => false],
     openapi: new Model\Operation(
-        summary: 'The given Role is removed from the User or User Group.',
+        summary: 'Unassign Role from User Group',
+        description: 'The given Role is removed from the User or User Group.',
         tags: [
             'User Group',
         ],

--- a/src/lib/Server/Controller/Role/RoleUpdateController.php
+++ b/src/lib/Server/Controller/Role/RoleUpdateController.php
@@ -17,10 +17,10 @@ use Symfony\Component\HttpFoundation\Response;
 
 #[Patch(
     uriTemplate: '/user/roles/{id}',
-    name: 'Update Role',
     extraProperties: [OpenApiFactory::OVERRIDE_OPENAPI_RESPONSES => false],
     openapi: new Model\Operation(
-        summary: 'Updates a Role. PATCH or POST with header X-HTTP-Method-Override PATCH',
+        summary: 'Update Role',
+        description: 'Updates a Role. PATCH or POST with header X-HTTP-Method-Override PATCH',
         tags: [
             'User Role',
         ],

--- a/src/lib/Server/Controller/Root.php
+++ b/src/lib/Server/Controller/Root.php
@@ -15,9 +15,9 @@ use Symfony\Component\HttpFoundation\Response;
 
 #[Get(
     uriTemplate: '/',
-    name: 'List of root resources',
     openapi: new Model\Operation(
-        summary: 'Lists the root resources of the Ibexa Platform installation.',
+        summary: 'List of root resources',
+        description: 'Lists the root resources of the Ibexa Platform installation.',
         tags: [
             'Root',
         ],

--- a/src/lib/Server/Controller/Section/SectionCreateController.php
+++ b/src/lib/Server/Controller/Section/SectionCreateController.php
@@ -21,10 +21,10 @@ use Symfony\Component\HttpFoundation\Response;
 
 #[Post(
     uriTemplate: '/content/sections',
-    name: 'Create new Section',
     extraProperties: [OpenApiFactory::OVERRIDE_OPENAPI_RESPONSES => false],
     openapi: new Model\Operation(
-        summary: 'Creates a new Section.',
+        summary: 'Create new Section',
+        description: 'Creates a new Section.',
         tags: [
             'Section',
         ],

--- a/src/lib/Server/Controller/Section/SectionDeleteController.php
+++ b/src/lib/Server/Controller/Section/SectionDeleteController.php
@@ -16,9 +16,9 @@ use Symfony\Component\HttpFoundation\Response;
 
 #[Delete(
     uriTemplate: '/content/sections/{sectionId}',
-    name: 'Delete Section',
     openapi: new Model\Operation(
-        summary: 'The given Section is deleted.',
+        summary: 'Delete Section',
+        description: 'The given Section is deleted.',
         tags: [
             'Section',
         ],

--- a/src/lib/Server/Controller/Section/SectionListController.php
+++ b/src/lib/Server/Controller/Section/SectionListController.php
@@ -19,10 +19,10 @@ use Symfony\Component\HttpFoundation\Response;
 
 #[Get(
     uriTemplate: '/content/sections',
-    name: 'Get Sections',
     extraProperties: [OpenApiFactory::OVERRIDE_OPENAPI_RESPONSES => false],
     openapi: new Model\Operation(
-        summary: 'Returns a list of all Sections.',
+        summary: 'Get Sections',
+        description: 'Returns a list of all Sections.',
         tags: [
             'Section',
         ],

--- a/src/lib/Server/Controller/Section/SectionLoadByIdController.php
+++ b/src/lib/Server/Controller/Section/SectionLoadByIdController.php
@@ -16,9 +16,9 @@ use Symfony\Component\HttpFoundation\Response;
 
 #[Get(
     uriTemplate: '/content/sections/{sectionId}',
-    name: 'Get Section',
     openapi: new Model\Operation(
-        summary: 'Returns the Section by given Section ID.',
+        summary: 'Get Section',
+        description: 'Returns the Section by given Section ID.',
         tags: [
             'Section',
         ],

--- a/src/lib/Server/Controller/Section/SectionUpdateController.php
+++ b/src/lib/Server/Controller/Section/SectionUpdateController.php
@@ -23,10 +23,10 @@ use Symfony\Component\HttpFoundation\Response;
 
 #[Patch(
     uriTemplate: '/content/sections/{sectionId}',
-    name: 'Update a Section',
     extraProperties: [OpenApiFactory::OVERRIDE_OPENAPI_RESPONSES => false],
     openapi: new Model\Operation(
-        summary: 'Updates a Section. PATCH or POST with header X-HTTP-Method-Override PATCH.',
+        summary: 'Update a Section',
+        description: 'Updates a Section. PATCH or POST with header X-HTTP-Method-Override PATCH.',
         tags: [
             'Section',
         ],

--- a/src/lib/Server/Controller/Services.php
+++ b/src/lib/Server/Controller/Services.php
@@ -15,9 +15,9 @@ use Symfony\Component\HttpFoundation\Response;
 
 #[Get(
     uriTemplate: '/services/countries',
-    name: 'Countries list',
     openapi: new Model\Operation(
-        summary: 'Gives access to an ISO-3166 formatted list of world countries. It is useful when presenting a country options list from any application.',
+        summary: 'Countries list',
+        description: 'Gives access to an ISO-3166 formatted list of world countries. It is useful when presenting a country options list from any application.',
         tags: [
             'Services',
         ],

--- a/src/lib/Server/Controller/Session/SessionCheckController.php
+++ b/src/lib/Server/Controller/Session/SessionCheckController.php
@@ -16,9 +16,9 @@ use Symfony\Component\HttpFoundation\Response;
 
 #[Get(
     uriTemplate: '/user/sessions/current',
-    name: 'Get current session',
     openapi: new Model\Operation(
-        summary: 'Get current user session, if any.',
+        summary: 'Get current session',
+        description: 'Get current user session, if any.',
         tags: [
             'User Session',
         ],

--- a/src/lib/Server/Controller/Session/SessionCreateController.php
+++ b/src/lib/Server/Controller/Session/SessionCreateController.php
@@ -22,10 +22,10 @@ use Symfony\Component\Security\Core\Exception\AuthenticationException;
 
 #[Post(
     uriTemplate: '/user/sessions',
-    name: 'Create session (login a User)',
     extraProperties: [OpenApiFactory::OVERRIDE_OPENAPI_RESPONSES => false],
     openapi: new Model\Operation(
-        summary: 'Performs a login for the user or checks if session exists and returns the session and session cookie. The client will need to remember both session name/ID and CSRF token as this is for security reasons not exposed via GET.',
+        summary: 'Create session (login a User)',
+        description: 'Performs a login for the user or checks if session exists and returns the session and session cookie. The client will need to remember both session name/ID and CSRF token as this is for security reasons not exposed via GET.',
         tags: [
             'User Session',
         ],

--- a/src/lib/Server/Controller/Session/SessionDeleteController.php
+++ b/src/lib/Server/Controller/Session/SessionDeleteController.php
@@ -16,9 +16,9 @@ use Symfony\Component\HttpFoundation\Response;
 
 #[Delete(
     uriTemplate: '/user/sessions/{sessionId}',
-    name: 'Delete session (logout a User)',
     openapi: new Model\Operation(
-        summary: 'The user session is removed i.e. the user is logged out.',
+        summary: 'Delete session (logout a User)',
+        description: 'The user session is removed i.e. the user is logged out.',
         tags: [
             'User Session',
         ],

--- a/src/lib/Server/Controller/Session/SessionRefreshController.php
+++ b/src/lib/Server/Controller/Session/SessionRefreshController.php
@@ -17,10 +17,10 @@ use Symfony\Component\HttpFoundation\Response;
 
 #[Post(
     uriTemplate: '/user/sessions/{sessionId}/refresh',
-    name: 'Refresh session (deprecated)',
     extraProperties: [OpenApiFactory::OVERRIDE_OPENAPI_RESPONSES => false],
     openapi: new Model\Operation(
-        summary: 'Get the session\'s User information. Deprecated as of Ibexa DXP 4.6, use GET /user/sessions/current instead.',
+        summary: 'Refresh session (deprecated)',
+        description: 'Get the session\'s User information. Deprecated as of Ibexa DXP 4.6, use GET /user/sessions/current instead.',
         tags: [
             'User Session',
         ],

--- a/src/lib/Server/Controller/Trash/TrashEmptyController.php
+++ b/src/lib/Server/Controller/Trash/TrashEmptyController.php
@@ -18,10 +18,10 @@ use Symfony\Component\HttpFoundation\Response;
 
 #[Delete(
     uriTemplate: '/content/trash',
-    name: 'Empty Trash',
     extraProperties: [OpenApiFactory::OVERRIDE_OPENAPI_RESPONSES => false],
     openapi: new Model\Operation(
-        summary: 'Empties the Trash.',
+        summary: 'Empty Trash',
+        description: 'Empties the Trash.',
         tags: [
             'Trash',
         ],

--- a/src/lib/Server/Controller/Trash/TrashItemDeleteController.php
+++ b/src/lib/Server/Controller/Trash/TrashItemDeleteController.php
@@ -17,9 +17,9 @@ use Symfony\Component\HttpFoundation\Response;
 
 #[Delete(
     uriTemplate: '/content/trash/{trashItemid}',
-    name: 'Delete Trash item',
     openapi: new Model\Operation(
-        summary: 'Deletes the provided item from Trash.',
+        summary: 'Delete Trash item',
+        description: 'Deletes the provided item from Trash.',
         tags: [
             'Trash',
         ],

--- a/src/lib/Server/Controller/Trash/TrashItemListController.php
+++ b/src/lib/Server/Controller/Trash/TrashItemListController.php
@@ -20,10 +20,10 @@ use Symfony\Component\HttpFoundation\Response;
 
 #[Get(
     uriTemplate: '/content/trash',
-    name: 'List Trash items',
     extraProperties: [OpenApiFactory::OVERRIDE_OPENAPI_RESPONSES => false],
     openapi: new Model\Operation(
-        summary: 'Returns a list of all items in the Trash.',
+        summary: 'List Trash items',
+        description: 'Returns a list of all items in the Trash.',
         tags: [
             'Trash',
         ],

--- a/src/lib/Server/Controller/Trash/TrashItemLoadByIdController.php
+++ b/src/lib/Server/Controller/Trash/TrashItemLoadByIdController.php
@@ -17,9 +17,9 @@ use Symfony\Component\HttpFoundation\Response;
 
 #[Get(
     uriTemplate: '/content/trash/{trashItemid}',
-    name: 'Get Trash item',
     openapi: new Model\Operation(
-        summary: 'Returns the item in Trash with the provided ID.',
+        summary: 'Get Trash item',
+        description: 'Returns the item in Trash with the provided ID.',
         tags: [
             'Trash',
         ],

--- a/src/lib/Server/Controller/URLAlias/URLAliasCreateController.php
+++ b/src/lib/Server/Controller/URLAlias/URLAliasCreateController.php
@@ -23,10 +23,10 @@ use Symfony\Component\HttpFoundation\Response;
 
 #[Post(
     uriTemplate: '/content/urlaliases',
-    name: 'Create URL alias',
     extraProperties: [OpenApiFactory::OVERRIDE_OPENAPI_RESPONSES => false],
     openapi: new Model\Operation(
-        summary: 'Creates a URL alias.',
+        summary: 'Create URL alias',
+        description: 'Creates a URL alias.',
         tags: [
             'Url Alias',
         ],

--- a/src/lib/Server/Controller/URLAlias/URLAliasDeleteController.php
+++ b/src/lib/Server/Controller/URLAlias/URLAliasDeleteController.php
@@ -17,9 +17,9 @@ use Symfony\Component\HttpFoundation\Response;
 
 #[Delete(
     uriTemplate: '/content/urlaliases/{urlAliasId}',
-    name: 'Delete URL alias',
     openapi: new Model\Operation(
-        summary: 'Deletes the provided URL alias.',
+        summary: 'Delete URL alias',
+        description: 'Deletes the provided URL alias.',
         tags: [
             'Url Alias',
         ],

--- a/src/lib/Server/Controller/URLAlias/URLAliasListGlobalController.php
+++ b/src/lib/Server/Controller/URLAlias/URLAliasListGlobalController.php
@@ -18,10 +18,10 @@ use Symfony\Component\HttpFoundation\Response;
 
 #[Get(
     uriTemplate: '/content/urlaliases',
-    name: 'List global URL aliases',
     extraProperties: [OpenApiFactory::OVERRIDE_OPENAPI_RESPONSES => false],
     openapi: new Model\Operation(
-        summary: 'Returns the list of global URL aliases.',
+        summary: 'List global URL aliases',
+        description: 'Returns the list of global URL aliases.',
         tags: [
             'Url Alias',
         ],

--- a/src/lib/Server/Controller/URLAlias/URLAliasListLocationController.php
+++ b/src/lib/Server/Controller/URLAlias/URLAliasListLocationController.php
@@ -19,10 +19,10 @@ use Symfony\Component\HttpFoundation\Response;
 
 #[Get(
     uriTemplate: '/content/locations/{path}/urlaliases',
-    name: 'List URL aliases for Location',
     extraProperties: [OpenApiFactory::OVERRIDE_OPENAPI_RESPONSES => false],
     openapi: new Model\Operation(
-        summary: 'Returns the list of URL aliases for a Location.',
+        summary: 'List URL aliases for Location',
+        description: 'Returns the list of URL aliases for a Location.',
         tags: [
             'Location',
         ],

--- a/src/lib/Server/Controller/URLAlias/URLAliasLoadByIdController.php
+++ b/src/lib/Server/Controller/URLAlias/URLAliasLoadByIdController.php
@@ -17,9 +17,9 @@ use Symfony\Component\HttpFoundation\Response;
 
 #[Get(
     uriTemplate: '/content/urlaliases/{urlAliasId}',
-    name: 'Get URL alias',
     openapi: new Model\Operation(
-        summary: 'Returns the URL alias with the given ID.',
+        summary: 'Get URL alias',
+        description: 'Returns the URL alias with the given ID.',
         tags: [
             'Url Alias',
         ],

--- a/src/lib/Server/Controller/URLWildcard/URLWildcardCreateController.php
+++ b/src/lib/Server/Controller/URLWildcard/URLWildcardCreateController.php
@@ -22,10 +22,10 @@ use Symfony\Component\HttpFoundation\Response;
 
 #[Post(
     uriTemplate: '/content/urlwildcards',
-    name: 'Create URL wildcard',
     extraProperties: [OpenApiFactory::OVERRIDE_OPENAPI_RESPONSES => false],
     openapi: new Model\Operation(
-        summary: 'Creates a new URL wildcard.',
+        summary: 'Create URL wildcard',
+        description: 'Creates a new URL wildcard.',
         tags: [
             'Url Wildcard',
         ],

--- a/src/lib/Server/Controller/URLWildcard/URLWildcardDeleteController.php
+++ b/src/lib/Server/Controller/URLWildcard/URLWildcardDeleteController.php
@@ -16,9 +16,9 @@ use Symfony\Component\HttpFoundation\Response;
 
 #[Delete(
     uriTemplate: '/content/urlwildcards/{wildcardId}',
-    name: 'Delete URL wildcard',
     openapi: new Model\Operation(
-        summary: 'Deletes the given URL wildcard.',
+        summary: 'Delete URL wildcard',
+        description: 'Deletes the given URL wildcard.',
         tags: [
             'Url Wildcard',
         ],

--- a/src/lib/Server/Controller/URLWildcard/URLWildcardListController.php
+++ b/src/lib/Server/Controller/URLWildcard/URLWildcardListController.php
@@ -17,10 +17,10 @@ use Symfony\Component\HttpFoundation\Response;
 
 #[Get(
     uriTemplate: '/content/urlwildcards',
-    name: 'List URL wildcards',
     extraProperties: [OpenApiFactory::OVERRIDE_OPENAPI_RESPONSES => false],
     openapi: new Model\Operation(
-        summary: 'Returns a list of URL wildcards.',
+        summary: 'List URL wildcards',
+        description: 'Returns a list of URL wildcards.',
         tags: [
             'Url Wildcard',
         ],

--- a/src/lib/Server/Controller/URLWildcard/URLWildcardLoadByIdController.php
+++ b/src/lib/Server/Controller/URLWildcard/URLWildcardLoadByIdController.php
@@ -16,9 +16,9 @@ use Symfony\Component\HttpFoundation\Response;
 
 #[Get(
     uriTemplate: '/content/urlwildcards/{wildcardId}',
-    name: 'Get URL wildcard',
     openapi: new Model\Operation(
-        summary: 'Returns the URL wildcard with the given ID.',
+        summary: 'Get URL wildcard',
+        description: 'Returns the URL wildcard with the given ID.',
         tags: [
             'Url Wildcard',
         ],

--- a/src/lib/Server/Controller/User/UserAssignToUserGroupController.php
+++ b/src/lib/Server/Controller/User/UserAssignToUserGroupController.php
@@ -20,10 +20,10 @@ use Symfony\Component\HttpFoundation\Response;
 
 #[Post(
     uriTemplate: '/user/users/{userId}/groups',
-    name: 'Assign User Group',
     extraProperties: [OpenApiFactory::OVERRIDE_OPENAPI_RESPONSES => false],
     openapi: new Model\Operation(
-        summary: 'Assigns the User to a User Group.',
+        summary: 'Assign User Group',
+        description: 'Assigns the User to a User Group.',
         tags: [
             'User',
         ],

--- a/src/lib/Server/Controller/User/UserCreateController.php
+++ b/src/lib/Server/Controller/User/UserCreateController.php
@@ -22,10 +22,10 @@ use Symfony\Component\HttpFoundation\Response;
 
 #[Post(
     uriTemplate: '/user/groups/{path}/users',
-    name: 'Create User',
     extraProperties: [OpenApiFactory::OVERRIDE_OPENAPI_RESPONSES => false],
     openapi: new Model\Operation(
-        summary: 'Creates a new User in the given Group.',
+        summary: 'Create User',
+        description: 'Creates a new User in the given Group.',
         tags: [
             'User Group',
         ],

--- a/src/lib/Server/Controller/User/UserDeleteController.php
+++ b/src/lib/Server/Controller/User/UserDeleteController.php
@@ -16,9 +16,9 @@ use Symfony\Component\HttpFoundation\Response;
 
 #[Delete(
     uriTemplate: '/user/users/{userId}',
-    name: 'Delete User',
     openapi: new Model\Operation(
-        summary: 'Deletes the given User.',
+        summary: 'Delete User',
+        description: 'Deletes the given User.',
         tags: [
             'User',
         ],

--- a/src/lib/Server/Controller/User/UserDraftListController.php
+++ b/src/lib/Server/Controller/User/UserDraftListController.php
@@ -19,10 +19,10 @@ use Symfony\Component\HttpFoundation\Response;
 
 #[Get(
     uriTemplate: '/user/users/{userId}/drafts',
-    name: 'Load user drafts',
     extraProperties: [OpenApiFactory::OVERRIDE_OPENAPI_RESPONSES => false],
     openapi: new Model\Operation(
-        summary: 'Loads user\'s drafts',
+        summary: 'Load user drafts',
+        description: 'Loads user\'s drafts',
         tags: [
             'User',
         ],

--- a/src/lib/Server/Controller/User/UserGroupCreateController.php
+++ b/src/lib/Server/Controller/User/UserGroupCreateController.php
@@ -19,10 +19,10 @@ use Symfony\Component\HttpFoundation\Response;
 
 #[Post(
     uriTemplate: '/user/groups/subgroups',
-    name: 'Create a top level User Group',
     extraProperties: [OpenApiFactory::OVERRIDE_OPENAPI_RESPONSES => false],
     openapi: new Model\Operation(
-        summary: 'Creates a top level User Group under the root. To create a child group under a parent group use \'/user/groups/{path}/subgroups\'.',
+        summary: 'Create a top level User Group',
+        description: 'Creates a top level User Group under the root. To create a child group under a parent group use \'/user/groups/{path}/subgroups\'.',
         tags: [
             'User Group',
         ],
@@ -91,10 +91,10 @@ use Symfony\Component\HttpFoundation\Response;
 )]
 #[Post(
     uriTemplate: '/user/groups/{path}/subgroups',
-    name: 'Create User Group',
     extraProperties: [OpenApiFactory::OVERRIDE_OPENAPI_RESPONSES => false],
     openapi: new Model\Operation(
-        summary: 'Creates a new User Group under the given parent. To create a top level group use \'/user/groups/subgroups\'.',
+        summary: 'Create User Group',
+        description: 'Creates a new User Group under the given parent. To create a top level group use \'/user/groups/subgroups\'.',
         tags: [
             'User Group',
         ],

--- a/src/lib/Server/Controller/User/UserGroupDeleteController.php
+++ b/src/lib/Server/Controller/User/UserGroupDeleteController.php
@@ -17,10 +17,10 @@ use Symfony\Component\HttpFoundation\Response;
 
 #[Delete(
     uriTemplate: '/user/groups/{path}',
-    name: 'Delete User Group',
     extraProperties: [OpenApiFactory::OVERRIDE_OPENAPI_RESPONSES => false],
     openapi: new Model\Operation(
-        summary: 'The given User Group is deleted.',
+        summary: 'Delete User Group',
+        description: 'The given User Group is deleted.',
         tags: [
             'User Group',
         ],

--- a/src/lib/Server/Controller/User/UserGroupListController.php
+++ b/src/lib/Server/Controller/User/UserGroupListController.php
@@ -21,10 +21,10 @@ use Symfony\Component\HttpFoundation\Response;
 
 #[Get(
     uriTemplate: '/user/groups',
-    name: 'Load User Groups',
     extraProperties: [OpenApiFactory::OVERRIDE_OPENAPI_RESPONSES => false],
     openapi: new Model\Operation(
-        summary: 'Loads User Groups for either an an ID or a remote ID or a Role.',
+        summary: 'Load User Groups',
+        description: 'Loads User Groups for either an an ID or a remote ID or a Role.',
         tags: [
             'User Group',
         ],

--- a/src/lib/Server/Controller/User/UserGroupLoadByPathController.php
+++ b/src/lib/Server/Controller/User/UserGroupLoadByPathController.php
@@ -18,9 +18,9 @@ use Symfony\Component\HttpFoundation\Response;
 
 #[Get(
     uriTemplate: '/user/groups/{path}',
-    name: 'Load User Group',
     openapi: new Model\Operation(
-        summary: 'Loads User Groups for the given {path}.',
+        summary: 'Load User Group',
+        description: 'Loads User Groups for the given {path}.',
         tags: [
             'User Group',
         ],

--- a/src/lib/Server/Controller/User/UserGroupOfRootLoadController.php
+++ b/src/lib/Server/Controller/User/UserGroupOfRootLoadController.php
@@ -16,10 +16,10 @@ use Symfony\Component\HttpFoundation\Response;
 
 #[Get(
     uriTemplate: '/user/groups/root',
-    name: 'Get root User Group',
     extraProperties: [OpenApiFactory::OVERRIDE_OPENAPI_RESPONSES => false],
     openapi: new Model\Operation(
-        summary: 'Redirects to the root User Group.',
+        summary: 'Get root User Group',
+        description: 'Redirects to the root User Group.',
         tags: [
             'User Group',
         ],

--- a/src/lib/Server/Controller/User/UserGroupUpdateController.php
+++ b/src/lib/Server/Controller/User/UserGroupUpdateController.php
@@ -18,10 +18,10 @@ use Symfony\Component\HttpFoundation\Response;
 
 #[Patch(
     uriTemplate: '/user/groups/{path}',
-    name: 'Update User Group',
     extraProperties: [OpenApiFactory::OVERRIDE_OPENAPI_RESPONSES => false],
     openapi: new Model\Operation(
-        summary: 'Updates a User Group. PATCH or POST with header X-HTTP-Method-Override PATCH.',
+        summary: 'Update User Group',
+        description: 'Updates a User Group. PATCH or POST with header X-HTTP-Method-Override PATCH.',
         tags: [
             'User Group',
         ],

--- a/src/lib/Server/Controller/User/UserGroupUsersListController.php
+++ b/src/lib/Server/Controller/User/UserGroupUsersListController.php
@@ -19,9 +19,9 @@ use Symfony\Component\HttpFoundation\Response;
 
 #[Get(
     uriTemplate: '/user/groups/{path}/users',
-    name: 'Load Users of Group',
     openapi: new Model\Operation(
-        summary: 'Loads the Users of the Group with the given ID.',
+        summary: 'Load Users of Group',
+        description: 'Loads the Users of the Group with the given ID.',
         tags: [
             'User Group',
         ],

--- a/src/lib/Server/Controller/User/UserGroupsOfUserListController.php
+++ b/src/lib/Server/Controller/User/UserGroupsOfUserListController.php
@@ -19,9 +19,9 @@ use Symfony\Component\HttpFoundation\Response;
 
 #[Get(
     uriTemplate: '/user/users/{userId}/groups',
-    name: 'Load Groups of User',
     openapi: new Model\Operation(
-        summary: 'Returns a list of User Groups the User belongs to. The returned list includes the resources for unassigning a User Group if the User is in multiple groups.',
+        summary: 'Load Groups of User',
+        description: 'Returns a list of User Groups the User belongs to. The returned list includes the resources for unassigning a User Group if the User is in multiple groups.',
         tags: [
             'User',
         ],

--- a/src/lib/Server/Controller/User/UserListController.php
+++ b/src/lib/Server/Controller/User/UserListController.php
@@ -14,9 +14,9 @@ use Symfony\Component\HttpFoundation\Response;
 
 #[Get(
     uriTemplate: '/user/users',
-    name: 'List Users',
     openapi: new Model\Operation(
-        summary: 'Load Users either for a given remote ID or Role.',
+        summary: 'List Users',
+        description: 'Load Users either for a given remote ID or Role.',
         tags: [
             'User',
         ],

--- a/src/lib/Server/Controller/User/UserLoadByIdController.php
+++ b/src/lib/Server/Controller/User/UserLoadByIdController.php
@@ -19,9 +19,9 @@ use Symfony\Component\HttpFoundation\Response;
 
 #[Get(
     uriTemplate: '/user/users/{userId}',
-    name: 'Load User',
     openapi: new Model\Operation(
-        summary: 'Loads User with the given ID.',
+        summary: 'Load User',
+        description: 'Loads User with the given ID.',
         tags: [
             'User',
         ],

--- a/src/lib/Server/Controller/User/UserRedirectToCurrentUserController.php
+++ b/src/lib/Server/Controller/User/UserRedirectToCurrentUserController.php
@@ -18,10 +18,10 @@ use Symfony\Component\Security\Core\User\UserInterface;
 
 #[Get(
     uriTemplate: '/user/current',
-    name: 'Load current User',
     extraProperties: [OpenApiFactory::OVERRIDE_OPENAPI_RESPONSES => false],
     openapi: new Model\Operation(
-        summary: 'Loads the current user.',
+        summary: 'Load current User',
+        description: 'Loads the current user.',
         tags: [
             'User',
         ],

--- a/src/lib/Server/Controller/User/UserSubGroupListController.php
+++ b/src/lib/Server/Controller/User/UserSubGroupListController.php
@@ -19,9 +19,9 @@ use Symfony\Component\HttpFoundation\Response;
 
 #[Get(
     uriTemplate: '/user/groups/{path}/subgroups',
-    name: 'Load subgroups',
     openapi: new Model\Operation(
-        summary: 'Returns a list of the subgroups.',
+        summary: 'Load subgroups',
+        description: 'Returns a list of the subgroups.',
         tags: [
             'User Group',
         ],

--- a/src/lib/Server/Controller/User/UserUnassignFromUserGroupController.php
+++ b/src/lib/Server/Controller/User/UserUnassignFromUserGroupController.php
@@ -18,9 +18,9 @@ use Symfony\Component\HttpFoundation\Response;
 
 #[Delete(
     uriTemplate: '/user/users/{userId}/groups/{groupId}',
-    name: 'Unassign User Group',
     openapi: new Model\Operation(
-        summary: 'Unassigns the User from a User Group.',
+        summary: 'Unassign User Group',
+        description: 'Unassigns the User from a User Group.',
         tags: [
             'User',
         ],

--- a/src/lib/Server/Controller/User/UserUpdateController.php
+++ b/src/lib/Server/Controller/User/UserUpdateController.php
@@ -19,10 +19,10 @@ use Symfony\Component\HttpFoundation\Response;
 
 #[Patch(
     uriTemplate: '/user/users/{userId}',
-    name: 'Update User',
     extraProperties: [OpenApiFactory::OVERRIDE_OPENAPI_RESPONSES => false],
     openapi: new Model\Operation(
-        summary: 'Updates a User.',
+        summary: 'Update User',
+        description: 'Updates a User.',
         tags: [
             'User',
         ],

--- a/src/lib/Server/Controller/User/UserVerifyController.php
+++ b/src/lib/Server/Controller/User/UserVerifyController.php
@@ -17,9 +17,9 @@ use Symfony\Component\HttpFoundation\Response;
 
 #[Head(
     uriTemplate: '/user/users',
-    name: 'Verify Users',
     openapi: new Model\Operation(
-        summary: 'Verifies if there are Users matching given filter.',
+        summary: 'Verify Users',
+        description: 'Verifies if there are Users matching given filter.',
         tags: [
             'User',
         ],

--- a/src/lib/Server/Controller/Views.php
+++ b/src/lib/Server/Controller/Views.php
@@ -23,10 +23,10 @@ use Symfony\Component\HttpFoundation\Response;
 
 #[Post(
     uriTemplate: '/views',
-    name: 'Search content',
     extraProperties: [OpenApiFactory::OVERRIDE_OPENAPI_RESPONSES => false],
     openapi: new Model\Operation(
-        summary: 'Executes a query and returns a View including the results.
+        summary: 'Search content',
+        description: 'Executes a query and returns a View including the results.
 View input reflects the criteria model of the public PHP API.
 Refer to [Search Criteria Reference](/en/latest/search/criteria_reference/search_criteria_reference/)',
         tags: [


### PR DESCRIPTION
| :ticket: Issue | IBX-9058 |
|----------------|-----------|

#### Related PRs: 

Same fix:
- ibexa/activity-log#120
- ibexa/calendar#69
- ibexa/cart#121
- ibexa/corporate-account#283
- ibexa/order-management#146
- ibexa/payment#168
- ibexa/product-catalog#1285
- ibexa/segmentation#124
- ibexa/shipping#106
- ibexa/taxonomy#322

Same ticket:
- #157
- #158
- #159

#### Description:

Before :

- The `name` was used as `operationId` in the export which can't contain spaces, `redocly lint` was throwing many "Operation `operationId` should not have URL invalid characters."
- The extracted schema contained useless generated descriptions.

```yaml
paths:
  /bookmark:
    get:
      operationId: 'List of bookmarks'
      summary: 'Lists bookmarked Locations for the current user.'
      description: 'Retrieves a BookmarkListController resource.'
```

After:

- `operationId` are generated.

```yaml
paths:
  /bookmark:
    get:
      operationId: api_bookmark_get
      summary: 'List of bookmarks'
      description: 'Lists bookmarked Locations for the current user.'
```

Swapping scripts:

For current `ibexa/rest`
```bash
find src/lib/Server/Controller -name '*.php' \
  -exec perl -i -p0e 's/^        summary:/        description:/mgis' {} \; \
  -exec perl -i -p0e 's/^    name:/    summary:/mgis' {} \; \
  -exec perl -i -p0e 's/(    summary: [^\n]+)\n(    openapi: [^\n]+)/$2\n    $1/gis' {} \; \
  -exec perl -i -p0e 's/(    summary: [^\n]+)\n(    extraProperties: [^\n]+)\n(    openapi: [^\n]+)/$2\n$3\n    $1/gis' {} \; \
;
```

For other packages:
```bash
find src/bundle/Controller/REST -name '*.php' \
  -exec perl -i -p0e 's/^        summary:/        description:/mgis' {} \; \
  -exec perl -i -p0e 's/^    name:/    summary:/mgis' {} \; \
  -exec perl -i -p0e 's/(    summary: [^\n]+)\n(    openapi: [^\n]+)/$2\n    $1/gis' {} \; \
  -exec perl -i -p0e 's/(    summary: [^\n]+)\n(    extraProperties: [^\n]+)\n(    openapi: [^\n]+)/$2\n$3\n    $1/gis' {} \; \
;
```

#### For QA:
<!-- Optional. Replace this comment with any necessary information needed by QA to test this Pull Request -->

#### Documentation:
<!-- Optional. Replace this comment with details helpful for writing the doc: overview, code snippets for extensibility etc. -->


<!-- 
Before you click submit:
    - Test the solution manually
    - Provide automated test coverage
    - Confirm that target branch is set correctly
    - For new features, confirm that you have suitable access control and injection prevention
    - Run PHP CS Fixer for new PHP code (use $ composer fix-cs)
    - Run ESLint and Prettier for new JS/SCSS code (use $ yarn fix)
    - Ask for a review (ping @ibexa/php-dev or @ibexa/javascript-dev depending on the changes) 
--> 
