### PR TITLE
IBX-9058: Adapt schemas to OpenAPI 3.1

### DIFF
--- a/src/bundle/Resources/api_platform/schemas/base_schemas.yml
+++ b/src/bundle/Resources/api_platform/schemas/base_schemas.yml
@@ -76,8 +76,7 @@ schemas:
                 type: string
             "#text":
                 description: Content type description.
-                type: string
-                nullable: true
+                type: [string, 'null']
     ValueObject:
         type: object
         required:
@@ -110,8 +109,7 @@ schemas:
                       type: string
                   "#text":
                       description: Translation contents.
-                      type: string
-                      nullable: true
+                      type: [string, 'null']
     KeyValue:
         description: Key-value structure
         type: object
@@ -122,8 +120,7 @@ schemas:
             _key:
                 type: string
             "#text":
-                type: string
-                nullable: true
+                type: [string, 'null']
     DateRange:
         allOf:
             - $ref: "#/components/schemas/BaseObject"

--- a/src/bundle/Resources/api_platform/schemas/content_types_schemas.yml
+++ b/src/bundle/Resources/api_platform/schemas/content_types_schemas.yml
@@ -72,8 +72,7 @@ schemas:
                         type: string
                     urlAliasSchema:
                         description: URL alias schema. If nothing is provided, $nameSchema will be used instead.
-                        type: string
-                        nullable: true
+                        type: [string, 'null']
                     nameSchema:
                         description: Name schema. Can be composed of FieldDefinition identifier place holders.
                         type: string
@@ -234,8 +233,7 @@ schemas:
                     remoteId:
                         type: string
                     urlAliasSchema:
-                        type: string
-                        nullable: true
+                        type: [string, 'null']
                     nameSchema:
                         type: string
                     isContainer:
@@ -356,8 +354,7 @@ schemas:
                         type: string
                     urlAliasSchema:
                         description: URL alias schema. If nothing is provided, $nameSchema will be used instead.
-                        type: string
-                        nullable: true
+                        type: [string, 'null']
                     nameSchema:
                         description: Name schema. Can be composed of FieldDefinition identifier place holders.
                         type: string

--- a/src/bundle/Resources/api_platform/schemas/language_schemas.yml
+++ b/src/bundle/Resources/api_platform/schemas/language_schemas.yml
@@ -11,8 +11,7 @@ schemas:
               properties:
                   languageId:
                       description: The language ID (auto generated).
-                      type: string
-                      nullable: true
+                      type: [string, 'null']
                   languageCode:
                       description: The languageCode code.
                       type: string


### PR DESCRIPTION
| :ticket: Issue | IBX-9058 |
|----------------|-----------|

#### Description:

- `nullable` was specific to only OpenAPI 3.0
- `null` is new in OpenAPI 3.1

#### For QA:
<!-- Optional. Replace this comment with any necessary information needed by QA to test this Pull Request -->

#### Documentation:
<!-- Optional. Replace this comment with details helpful for writing the doc: overview, code snippets for extensibility etc. -->


<!-- 
Before you click submit:
    - Test the solution manually
    - Provide automated test coverage
    - Confirm that target branch is set correctly
    - For new features, confirm that you have suitable access control and injection prevention
    - Run PHP CS Fixer for new PHP code (use $ composer fix-cs)
    - Run ESLint and Prettier for new JS/SCSS code (use $ yarn fix)
    - Ask for a review (ping @ibexa/php-dev or @ibexa/javascript-dev depending on the changes) 
--> 
