### PR TITLE
IBX-9058: Fix OpenApi type/$ref/oneOf usage

### DIFF
--- a/src/bundle/Resources/api_platform/schemas/base_schemas.yml
+++ b/src/bundle/Resources/api_platform/schemas/base_schemas.yml
@@ -15,8 +15,7 @@ schemas:
                     name: href
                 type: string
     Ref:
-        type:
-            $ref: "#/components/schemas/BaseObject"
+        $ref: "#/components/schemas/BaseObject"
     UnixTimestamp:
         type: integer
     Href:
@@ -48,8 +47,7 @@ schemas:
                 type: string
             targetData:
                 description: Extra target data, required by some sort clauses, field for instance.
-                type:
-                    $ref: "#/components/schemas/Target"
+                $ref: "#/components/schemas/Target"
     ErrorMessage:
         description: Represents an error response. Might contain additional properties depending on an error type.
         type: object

--- a/src/bundle/Resources/api_platform/schemas/bookmarks_schemas.yml
+++ b/src/bundle/Resources/api_platform/schemas/bookmarks_schemas.yml
@@ -20,8 +20,7 @@ schemas:
                         - __href
                     properties:
                         Location:
-                            type:
-                                $ref: "#/components/schemas/Location"
+                            $ref: "#/components/schemas/Location"
                         _media-type:
                             type: string
                         __href:
@@ -32,8 +31,7 @@ schemas:
             - BookmarkList
         properties:
             BookmarkList:
-                type:
-                    $ref: "#/components/schemas/BookmarkList"
+                $ref: "#/components/schemas/BookmarkList"
     SummaryEntry:
         type: object
         required:
@@ -53,28 +51,20 @@ schemas:
             id:
                 type: integer
             names:
-                type:
-                    $ref: "#/components/schemas/SummaryEntryNames"
+                $ref: "#/components/schemas/SummaryEntryNames"
             quantity:
                 type: integer
             Price:
-                type:
-                    $ref: "#/components/schemas/RestPriceWrapper"
+                $ref: "#/components/schemas/RestPriceWrapper"
             PriceInclVat:
-                type:
-                    $ref: "#/components/schemas/RestPriceWrapper"
+                $ref: "#/components/schemas/RestPriceWrapper"
             SubtotalPrice:
-                type:
-                    $ref: "#/components/schemas/RestPriceWrapper"
+                $ref: "#/components/schemas/RestPriceWrapper"
             SubtotalPriceInclVat:
-                type:
-                    $ref: "#/components/schemas/RestPriceWrapper"
+                $ref: "#/components/schemas/RestPriceWrapper"
             VatCategory:
-                type:
-                    $ref: "#/components/schemas/VatCategory"
+                $ref: "#/components/schemas/VatCategory"
             Product:
-                type:
-                    $ref: "#/components/schemas/Product"
+                $ref: "#/components/schemas/Product"
     SummaryEntryNames:
-        type:
-            $ref: "#/components/schemas/ValueObject"
+        $ref: "#/components/schemas/ValueObject"

--- a/src/bundle/Resources/api_platform/schemas/content_locations_schemas.yml
+++ b/src/bundle/Resources/api_platform/schemas/content_locations_schemas.yml
@@ -36,8 +36,7 @@ schemas:
                       type: string
                   ContentInfo:
                       description: This class provides all version independent information of the content item.
-                      type:
-                          $ref: "#/components/schemas/ContentInfo"
+                      $ref: "#/components/schemas/ContentInfo"
                   ParentLocation:
                       description: Parent Location.
                   Children:

--- a/src/bundle/Resources/api_platform/schemas/content_objects_schemas.yml
+++ b/src/bundle/Resources/api_platform/schemas/content_objects_schemas.yml
@@ -34,31 +34,25 @@ schemas:
               type: integer
             ContentType:
               description: Content type.
-              type:
-                $ref: "#/components/schemas/BaseObject"
+              $ref: "#/components/schemas/BaseObject"
             Name:
               description: Name of the domain object in a given language.
               type: string
             Versions:
               description: Returns the VersionInfo for this version.
-              type:
-                $ref: "#/components/schemas/BaseObject"
+              $ref: "#/components/schemas/BaseObject"
             CurrentVersion:
               description: Current version.
-              type:
-                $ref: "#/components/schemas/BaseObject"
+              $ref: "#/components/schemas/BaseObject"
             Section:
               description: The Section to which the content item is assigned to.
-              type:
-                $ref: "#/components/schemas/BaseObject"
+              $ref: "#/components/schemas/BaseObject"
             Locations:
               description: Location of the content item.
-              type:
-                $ref: "#/components/schemas/BaseObject"
+              $ref: "#/components/schemas/BaseObject"
             Owner:
               description: The owner of the content item.
-              type:
-                $ref: "#/components/schemas/BaseObject"
+              $ref: "#/components/schemas/BaseObject"
             lastModificationDate:
               description: Content item modification date.
               type: string
@@ -81,8 +75,7 @@ schemas:
               type: string
             ObjectStates:
               description: Object states.
-              type:
-                $ref: "#/components/schemas/BaseObject"
+              $ref: "#/components/schemas/BaseObject"
     ContentWrapper:
       type: object
       required:
@@ -101,14 +94,12 @@ schemas:
       properties:
         ContentType:
           description: The content type for which the new content item is created.
-          type:
-            oneOf:
-              - "#/components/schemas/Content"
-              - "#/components/schemas/Href"
+          oneOf:
+            - "#/components/schemas/Content"
+            - "#/components/schemas/Href"
         Section:
           description: The Section the content item is assigned to. If not set the Section of the parent is used or a default Section.
-          type:
-            $ref: "#/components/schemas/Href"
+          $ref: "#/components/schemas/Href"
         User:
           description: The owner of the content. If not given the current authenticated User is set as owner.
           type: integer
@@ -157,14 +148,11 @@ schemas:
         mainLanguageCode:
           type: string
         Section:
-          type:
-            $ref: "#/components/schemas/Section"
+          $ref: "#/components/schemas/Section"
         MainLocation:
-          type:
-            $ref: "#/components/schemas/Location"
+          $ref: "#/components/schemas/Location"
         Owner:
-          type:
-            $ref: "#/components/schemas/User"
+          $ref: "#/components/schemas/User"
         alwaysAvailable:
           type: boolean
         remoteId:
@@ -179,8 +167,7 @@ schemas:
           properties:
             Content:
               description: Content ID matcher class.
-              type:
-                $ref: "#/components/schemas/Content"
+              $ref: "#/components/schemas/Content"
     ContentInfoWrapper:
       type: object
       required:
@@ -290,8 +277,7 @@ schemas:
           format: date-time
         Creator:
           description: Creator of the version, in the search API this is referred to as the modifier of the published content.
-          type:
-            $ref: "#/components/schemas/BaseObject"
+          $ref: "#/components/schemas/BaseObject"
         creationDate:
           description: Content creation date.
           type: string
@@ -306,12 +292,10 @@ schemas:
           description: Translation information.
         names:
           description: Names.
-          type:
-            $ref: "#/components/schemas/ValueArray"
+          $ref: "#/components/schemas/ValueArray"
         Content:
           description: Represents a content item in a specific version.
-          type:
-            $ref: "#/components/schemas/BaseObject"
+          $ref: "#/components/schemas/BaseObject"
     Version:
       allOf:
         - $ref: "#/components/schemas/BaseObject"
@@ -407,11 +391,9 @@ schemas:
       properties:
         Version:
           description: Returns the VersionInfo for this version.
-          type:
-            $ref: "#/components/schemas/BaseObject"
+          $ref: "#/components/schemas/BaseObject"
         VersionInfo:
-          type:
-            $ref: "#/components/schemas/VersionInfo"
+          $ref: "#/components/schemas/VersionInfo"
     VersionTranslationInfo:
       description: Translation information.
       type: object
@@ -445,12 +427,10 @@ schemas:
           properties:
             SourceContent:
               description: The content of the source content of the relation.
-              type:
-                $ref: "#/components/schemas/Ref"
+              $ref: "#/components/schemas/Ref"
             DestinationContent:
               description: The content of the destination content of the relation.
-              type:
-                $ref: "#/components/schemas/Ref"
+              $ref: "#/components/schemas/Ref"
             RelationType:
               description: "The relation type bitmask. Relations: Relation::COMMON = 1, Relation::EMBED = 2, Relation::LINK = 4, Relation::FIELD = 8, Relation::ASSET = 16"
               type: string
@@ -467,8 +447,7 @@ schemas:
         - Destination
       properties:
         Destination:
-          type:
-            $ref: "#/components/schemas/Href"
+          $ref: "#/components/schemas/Href"
     RelationCreateWrapper:
       type: object
       required:

--- a/src/bundle/Resources/api_platform/schemas/content_trash_schemas.yml
+++ b/src/bundle/Resources/api_platform/schemas/content_trash_schemas.yml
@@ -19,8 +19,7 @@ schemas:
                 $ref: "#/components/schemas/Trash"
     TrashItem:
         description: This class represents a trash item, which is actually a trashed Location.
-        type:
-            $ref: "#/components/schemas/Location"
+        $ref: "#/components/schemas/Location"
     TrashItemWrapper:
         type: object
         required:

--- a/src/bundle/Resources/api_platform/schemas/content_type_groups_schemas.yml
+++ b/src/bundle/Resources/api_platform/schemas/content_type_groups_schemas.yml
@@ -29,16 +29,13 @@ schemas:
                         format: date-time
                     Creator:
                         description: Creator User ID.
-                        type:
-                            $ref: "#/components/schemas/BaseObject"
+                        $ref: "#/components/schemas/BaseObject"
                     Modifier:
                         description: Modifier User ID.
-                        type:
-                            $ref: "#/components/schemas/BaseObject"
+                        $ref: "#/components/schemas/BaseObject"
                     ContentTypes:
                         description: Content types.
-                        type:
-                            $ref: "#/components/schemas/BaseObject"
+                        $ref: "#/components/schemas/BaseObject"
     ContentTypeGroupWrapper:
         type: object
         required:
@@ -81,8 +78,7 @@ schemas:
                     - ContentTypeGroupRef
                 properties:
                     ContentTypeGroupRef:
-                        type:
-                            $ref: "#/components/schemas/ContentTypeGroupRef"
+                        $ref: "#/components/schemas/ContentTypeGroupRef"
     ContentTypeGroupList:
         allOf:
             -   $ref: "#/components/schemas/BaseObject"

--- a/src/bundle/Resources/api_platform/schemas/content_types_schemas.yml
+++ b/src/bundle/Resources/api_platform/schemas/content_types_schemas.yml
@@ -53,20 +53,16 @@ schemas:
                         format: date-time
                     Creator:
                         description: Creator User of the content type.
-                        type:
-                            $ref: "#/components/schemas/BaseObject"
+                        $ref: "#/components/schemas/BaseObject"
                     Modifier:
                         description: Modifier User of the content type.
-                        type:
-                            $ref: "#/components/schemas/BaseObject"
+                        $ref: "#/components/schemas/BaseObject"
                     Groups:
                         description: Group User of the content type.
-                        type:
-                            $ref: "#/components/schemas/BaseObject"
+                        $ref: "#/components/schemas/BaseObject"
                     Draft:
                         description: Draft of the content type.
-                        type:
-                            $ref: "#/components/schemas/BaseObject"
+                        $ref: "#/components/schemas/BaseObject"
                     remoteId:
                         description: Unique remote ID of the content type.
                         type: string
@@ -146,14 +142,11 @@ schemas:
             defaultAlwaysAvailable:
                 type: boolean
             names:
-                type:
-                    $ref: "#/components/schemas/ValueObject"
+                $ref: "#/components/schemas/ValueObject"
             descriptions:
-                type:
-                    $ref: "#/components/schemas/ValueObject"
+                $ref: "#/components/schemas/ValueObject"
             FieldDefinition:
-                type:
-                    $ref: "#/components/schemas/FieldDefinition"
+                $ref: "#/components/schemas/FieldDefinition"
             creatorId:
                 description: If set, this value overrides the current user as creator.
             creationDate:
@@ -247,11 +240,9 @@ schemas:
                     defaultAlwaysAvailable:
                         type: [ string, boolean ]
                     names:
-                        type:
-                            $ref: "#/components/schemas/ValueObject"
+                        $ref: "#/components/schemas/ValueObject"
                     descriptions:
-                        type:
-                            $ref: "#/components/schemas/ValueObject"
+                        $ref: "#/components/schemas/ValueObject"
                     modifierId:
                         description: If set, this value overrides the current user as creator.
                     modificationDate:
@@ -337,20 +328,16 @@ schemas:
                         format: date-time
                     Creator:
                         description: Creator User of the content type.
-                        type:
-                            $ref: "#/components/schemas/BaseObject"
+                        $ref: "#/components/schemas/BaseObject"
                     Modifier:
                         description: Modifier User of the content type.
-                        type:
-                            $ref: "#/components/schemas/BaseObject"
+                        $ref: "#/components/schemas/BaseObject"
                     Groups:
                         description: Group User of the content type.
-                        type:
-                            $ref: "#/components/schemas/BaseObject"
+                        $ref: "#/components/schemas/BaseObject"
                     Draft:
                         description: Draft of the content type.
-                        type:
-                            $ref: "#/components/schemas/BaseObject"
+                        $ref: "#/components/schemas/BaseObject"
                     remoteId:
                         description: Unique remote ID of the content type.
                         type: string
@@ -495,10 +482,9 @@ schemas:
                         description: Settings for the Field definition supported by the field type.
                     validatorConfiguration:
                         description: Validator configuration of this Field definition supported by the field type.
-                        type:
-                            oneOf:
-                                - StringLengthValidatorWrapper
-                                - array
+                        oneOf:
+                            - StringLengthValidatorWrapper
+                            - array
     FieldDefinitionWrapper:
         type: object
         required:
@@ -507,8 +493,7 @@ schemas:
             FieldDefinition:
                 $ref: "#/components/schemas/FieldDefinition"
     FieldDefinitionCreate:
-        type:
-            $ref: "#/components/schemas/BaseObject"
+        $ref: "#/components/schemas/BaseObject"
     FieldDefinitionCreateWrapper:
         type: object
         required:
@@ -517,8 +502,7 @@ schemas:
             FieldDefinitionCreate:
                 $ref: "#/components/schemas/FieldDefinitionCreate"
     FieldDefinitionUpdate:
-        type:
-            $ref: "#/components/schemas/BaseObject"
+        $ref: "#/components/schemas/BaseObject"
     FieldDefinitionUpdateWrapper:
         type: object
         required:

--- a/src/bundle/Resources/api_platform/schemas/content_url_aliases_schemas.yml
+++ b/src/bundle/Resources/api_platform/schemas/content_url_aliases_schemas.yml
@@ -66,8 +66,7 @@ schemas:
             _type:
                 type: string
             location:
-                type:
-                    $ref: "#/components/schemas/Href"
+                $ref: "#/components/schemas/Href"
             resource:
                 type: string
             languageCode:

--- a/src/bundle/Resources/api_platform/schemas/object_state_groups_schemas.yml
+++ b/src/bundle/Resources/api_platform/schemas/object_state_groups_schemas.yml
@@ -24,8 +24,7 @@ schemas:
                         type: integer
                     ObjectStateGroup:
                         description: The Object state group this Object state belongs to.
-                        type:
-                            $ref: "#/components/schemas/BaseObject"
+                        $ref: "#/components/schemas/BaseObject"
                     languageCodes:
                         description: The available language codes for names an descriptions.
                         type: string
@@ -158,8 +157,7 @@ schemas:
                         type: string
                     ObjectStates:
                         description: Object States.
-                        type:
-                            $ref: "#/components/schemas/BaseObject"
+                        $ref: "#/components/schemas/BaseObject"
                     names:
                         description: List of names.
                     descriptions:

--- a/src/bundle/Resources/api_platform/schemas/root_schemas.yml
+++ b/src/bundle/Resources/api_platform/schemas/root_schemas.yml
@@ -30,108 +30,82 @@ schemas:
                 properties:
                     content:
                         description: Content.
-                        type:
-                            $ref: "#/components/schemas/BaseObject"
+                        $ref: "#/components/schemas/BaseObject"
                     contentByRemoteId:
                         description: Content by the given remote ID.
-                        type:
-                            $ref: "#/components/schemas/BaseObject"
+                        $ref: "#/components/schemas/BaseObject"
                     contentTypes:
                         description: Content types.
-                        type:
-                            $ref: "#/components/schemas/BaseObject"
+                        $ref: "#/components/schemas/BaseObject"
                     contentTypeByIdentifier:
                         description: Content type by the given identifier.
-                        type:
-                            $ref: "#/components/schemas/BaseObject"
+                        $ref: "#/components/schemas/BaseObject"
                     contentTypeGroups:
                         description: Content type Groups.
-                        type:
-                            $ref: "#/components/schemas/BaseObject"
+                        $ref: "#/components/schemas/BaseObject"
                     contentTypeGroupByIdentifier:
                         description: Content type Groups by the given identifier.
-                        type:
-                            $ref: "#/components/schemas/BaseObject"
+                        $ref: "#/components/schemas/BaseObject"
                     users:
                         description: Users.
-                        type:
-                            $ref: "#/components/schemas/BaseObject"
+                        $ref: "#/components/schemas/BaseObject"
                     usersByRoleId:
                         description: Users by Role ID.
-                        type:
-                            $ref: "#/components/schemas/BaseObject"
+                        $ref: "#/components/schemas/BaseObject"
                     usersByRemoteId:
                         description: Users by remote ID.
-                        type:
-                            $ref: "#/components/schemas/BaseObject"
+                        $ref: "#/components/schemas/BaseObject"
                     usersByEmail:
                         description: Users by e-mail.
-                        type:
-                            $ref: "#/components/schemas/BaseObject"
+                        $ref: "#/components/schemas/BaseObject"
                     usersByLogin:
                         description: Users by login.
-                        type:
-                            $ref: "#/components/schemas/BaseObject"
+                        $ref: "#/components/schemas/BaseObject"
                     roles:
                         description: Roles.
-                        type:
-                            $ref: "#/components/schemas/BaseObject"
+                        $ref: "#/components/schemas/BaseObject"
                     rootLocation:
                         description: Root Location.
-                        type:
-                            $ref: "#/components/schemas/BaseObject"
+                        $ref: "#/components/schemas/BaseObject"
                     rootUserGroup:
                         description: Root User Group.
-                        type:
-                            $ref: "#/components/schemas/BaseObject"
+                        $ref: "#/components/schemas/BaseObject"
                     rootMediaFolder:
                         description: Root media folder.
-                        type:
-                            $ref: "#/components/schemas/BaseObject"
+                        $ref: "#/components/schemas/BaseObject"
                     locationByRemoteId:
                         description: Location by remote ID.
-                        type:
-                            $ref: "#/components/schemas/BaseObject"
+                        $ref: "#/components/schemas/BaseObject"
                     locationByPath:
                         description: Location by path.
-                        type:
-                            $ref: "#/components/schemas/BaseObject"
+                        $ref: "#/components/schemas/BaseObject"
                     trash:
                         description: Trash.
-                        type:
-                            $ref: "#/components/schemas/BaseObject"
+                        $ref: "#/components/schemas/BaseObject"
                     sections:
                         description: Sections.
-                        type:
-                            $ref: "#/components/schemas/BaseObject"
+                        $ref: "#/components/schemas/BaseObject"
                     views:
                         description: Views.
-                        type:
-                            $ref: "#/components/schemas/BaseObject"
+                        $ref: "#/components/schemas/BaseObject"
                     objectStateGroups:
                         description: Object state groups.
-                        type:
-                            $ref: "#/components/schemas/BaseObject"
+                        $ref: "#/components/schemas/BaseObject"
                     objectStates:
                         description: Object states.
-                        type:
-                            $ref: "#/components/schemas/BaseObject"
+                        $ref: "#/components/schemas/BaseObject"
                     globalUrlAliases:
                         description: Global URL aliases.
-                        type:
-                            $ref: "#/components/schemas/BaseObject"
+                        $ref: "#/components/schemas/BaseObject"
                     urlWildcards:
                         description: URL Wildcards.
-                        type:
-                            $ref: "#/components/schemas/BaseObject"
+                        $ref: "#/components/schemas/BaseObject"
                     createSession:
                         description: Creates a new session based on the credentials provided as POST parameters.
-                        type:
-                            $ref: "#/components/schemas/BaseObject"
+                        $ref: "#/components/schemas/BaseObject"
                     refreshSession:
                         description: Refresh given session.
-                        type:
-                            $ref: "#/components/schemas/BaseObject"
+                        $ref: "#/components/schemas/BaseObject"
     RootWrapper:
         type: object
         required:

--- a/src/bundle/Resources/api_platform/schemas/user/roles_schemas.yml
+++ b/src/bundle/Resources/api_platform/schemas/user/roles_schemas.yml
@@ -13,8 +13,7 @@ schemas:
                         type: string
                     Policies:
                         description: Returns the list of policies of this role.
-                        type:
-                            $ref: "#/components/schemas/BaseObject"
+                        $ref: "#/components/schemas/BaseObject"
     RoleWrapper:
         type: object
         required:
@@ -24,8 +23,7 @@ schemas:
                 $ref: "#/components/schemas/Role"
     RoleDraft:
         description: This class represents a draft of a role, extends Role.
-        type:
-            $ref: "#/components/schemas/Role"
+        $ref: "#/components/schemas/Role"
     RoleDraftWrapper:
         type: object
         required:
@@ -221,8 +219,7 @@ schemas:
                         description: Returns the limitation of the role assignment.
                     Role:
                         description: Returns the role to which the User or User group is assigned to.
-                        type:
-                            $ref: "#/components/schemas/Ref"
+                        $ref: "#/components/schemas/Ref"
     RoleAssignmentWrapper:
         type: object
         required:
@@ -239,12 +236,10 @@ schemas:
         properties:
             Role:
                 description: Returns the Role to which the user or user group is assigned to.
-                type:
-                    $ref: "#/components/schemas/Ref"
+                $ref: "#/components/schemas/Ref"
             limitation:
                 description: Returns the Limitation of the Role assignment.
-                type:
-                    $ref: "#/components/schemas/Limitation"
+                $ref: "#/components/schemas/Limitation"
     RoleAssignInputWrapper:
         type: object
         required:

--- a/src/bundle/Resources/api_platform/schemas/user/sessions_schemas.yml
+++ b/src/bundle/Resources/api_platform/schemas/user/sessions_schemas.yml
@@ -21,8 +21,7 @@ schemas:
                         type: string
                     User:
                         description: User.
-                        type:
-                            $ref: "#/components/schemas/BaseObject"
+                        $ref: "#/components/schemas/BaseObject"
     SessionWrapper:
         type: object
         required:

--- a/src/bundle/Resources/api_platform/schemas/user/user_groups_schemas.yml
+++ b/src/bundle/Resources/api_platform/schemas/user/user_groups_schemas.yml
@@ -37,29 +37,23 @@ schemas:
                         type: integer
                     ContentType:
                         description: Content type.
-                        type:
-                            $ref: "#/components/schemas/Ref"
+                        $ref: "#/components/schemas/Ref"
                     name:
                         type: string
                     Versions:
                         description: Returns the VersionInfo for this version.
-                        type:
-                            $ref: "#/components/schemas/Ref"
+                        $ref: "#/components/schemas/Ref"
                     Section:
                         description: The Section to which the content item is assigned to.
-                        type:
-                            $ref: "#/components/schemas/Ref"
+                        $ref: "#/components/schemas/Ref"
                     MainLocation:
-                        type:
-                            $ref: "#/components/schemas/Ref"
+                        $ref: "#/components/schemas/Ref"
                     Locations:
                         description: Location of the content item.
-                        type:
-                            $ref: "#/components/schemas/Ref"
+                        $ref: "#/components/schemas/Ref"
                     Owner:
                         description: The owner of the content item.
-                        type:
-                            $ref: "#/components/schemas/Ref"
+                        $ref: "#/components/schemas/Ref"
                     lastModificationDate:
                         description: Content item modification date.
                         type: string
@@ -72,17 +66,13 @@ schemas:
                     Version:
                         $ref: "#/components/schemas/Version"
                     ParentUserGroup:
-                        type:
-                            $ref: "#/components/schemas/Ref"
+                        $ref: "#/components/schemas/Ref"
                     Subgroups:
-                        type:
-                            $ref: "#/components/schemas/Ref"
+                        $ref: "#/components/schemas/Ref"
                     Users:
-                        type:
-                            $ref: "#/components/schemas/Ref"
+                        $ref: "#/components/schemas/Ref"
                     Roles:
-                        type:
-                            $ref: "#/components/schemas/Ref"
+                        $ref: "#/components/schemas/Ref"
     UserGroupWrapper:
         type: object
         required:
@@ -92,8 +82,7 @@ schemas:
                 $ref: "#/components/schemas/UserGroup"
     UserGroupList:
         description: This class represents a User Group list.
-        type:
-            $ref: "#/components/schemas/BaseObject"
+        $ref: "#/components/schemas/BaseObject"
     UserGroupListWrapper:
         type: object
         required:
@@ -134,8 +123,7 @@ schemas:
             remoteId:
                 type: string
             fields:
-                type:
-                    $ref: "#/components/schemas/Fields"
+                $ref: "#/components/schemas/Fields"
     UserGroupCreateWrapper:
         type: object
         required:
@@ -175,8 +163,7 @@ schemas:
                     - Unassign
                 properties:
                     Unassign:
-                        type:
-                            $ref: "#/components/schemas/Unlink"
+                        $ref: "#/components/schemas/Unlink"
     Unlink:
         description: Unlink a content type group from a content type.
         type: object

--- a/src/bundle/Resources/api_platform/schemas/user/users_schemas.yml
+++ b/src/bundle/Resources/api_platform/schemas/user/users_schemas.yml
@@ -40,35 +40,28 @@ schemas:
                         type: string
                     ContentType:
                         description: This class represents a content type.
-                        type:
-                            $ref: "#/components/schemas/BaseObject"
+                        $ref: "#/components/schemas/BaseObject"
                     name:
                         description: Name of the domain object in a given language.
                         type: string
                     Versions:
                         description: Returns the VersionInfo for this version.
-                        type:
-                            $ref: "#/components/schemas/BaseObject"
+                        $ref: "#/components/schemas/BaseObject"
                     Section:
                         description: The Section to which the content item is assigned.
-                        type:
-                            $ref: "#/components/schemas/BaseObject"
+                        $ref: "#/components/schemas/BaseObject"
                     MainLocation:
                         description: Main Location of the object.
-                        type:
-                            $ref: "#/components/schemas/BaseObject"
+                        $ref: "#/components/schemas/BaseObject"
                     Locations:
                         description: Locations of the object.
-                        type:
-                            $ref: "#/components/schemas/BaseObject"
+                        $ref: "#/components/schemas/BaseObject"
                     Groups:
                         description: Group User of the content type.
-                        type:
-                            $ref: "#/components/schemas/BaseObject"
+                        $ref: "#/components/schemas/BaseObject"
                     Owner:
                         description: The owner of the content item.
-                        type:
-                            $ref: "#/components/schemas/BaseObject"
+                        $ref: "#/components/schemas/BaseObject"
                     publishDate:
                         description: Content publication date.
                         type: string
@@ -96,12 +89,10 @@ schemas:
                         type: boolean
                     UserGroups:
                         description: User groups.
-                        type:
-                            $ref: "#/components/schemas/BaseObject"
+                        $ref: "#/components/schemas/BaseObject"
                     Roles:
                         description: Roles.
-                        type:
-                            $ref: "#/components/schemas/BaseObject"
+                        $ref: "#/components/schemas/BaseObject"
     UserWrapper:
         type: object
         required:

--- a/src/bundle/Resources/api_platform/schemas/views_schemas.yml
+++ b/src/bundle/Resources/api_platform/schemas/views_schemas.yml
@@ -13,16 +13,13 @@ schemas:
                 description: Content identifier.
                 type: string
             User:
-                type:
-                    $ref: "#/components/schemas/User"
+                $ref: "#/components/schemas/User"
             public:
                 type: boolean
             LocationQuery:
-                type:
-                    $ref: "#/components/schemas/LocationQuery"
+                $ref: "#/components/schemas/LocationQuery"
             Result:
-                type:
-            $ref: "#/components/schemas/BaseObject"
+                $ref: "#/components/schemas/BaseObject"
     ViewInput:
         description: This class represents a View input.
         type: object
@@ -38,8 +35,7 @@ schemas:
             useAlwaysAvailable:
                 type: string
             Query:
-                type:
-                    $ref: "#/components/schemas/Query"
+                $ref: "#/components/schemas/Query"
     ViewInputWrapper:
         type: object
         required:
@@ -53,12 +49,10 @@ schemas:
         properties:
             Filter:
                 description: The Query filter. Can contain multiple criterion, as items of a logical one (by default AND).
-                type:
-                    $ref: "#/components/schemas/Criterion"
+                $ref: "#/components/schemas/Criterion"
             Query:
                 description: The Query query. Can contain multiple criterion, as items of a logical one (by default AND).
-                type:
-                    $ref: "#/components/schemas/Criterion"
+                $ref: "#/components/schemas/Criterion"
             sortClauses:
                 description: Query sorting clauses.
                 type: array
@@ -120,8 +114,7 @@ schemas:
                 type: boolean
             filter:
                 description: An additional facet filter that will further filter the documents the facet will be executed on.
-                type:
-                    $ref: "#/components/schemas/Criterion"
+                $ref: "#/components/schemas/Criterion"
             limit:
                 description: Number of facets (terms) returned.
                 type: integer


### PR DESCRIPTION
| :ticket: Issue | IBX-9058 |
|----------------|-----------|

#### Related PRs: 

Same fix:
- ibexa/calendar#70
- ibexa/cart#122
- ibexa/corporate-account#284
- ibexa/order-management#147
- ibexa/product-catalog#1286
- ibexa/shipping#107
- ibexa/taxonomy#323

Same ticket:
- #156
- #157
- #158

#### Description:

Fix some `redocly lint` errors

- ```
  `type` can be one of the following only: "object", "array", "string", "number", "integer", "boolean", "null".
  ```
- `Error: Objects are not valid as a React child (found: object with keys {type, required, properties}). If you meant to render a collection of children, use an array instead.`
- `Error: Objects are not valid as a React child (found: object with keys {oneOf}). If you meant to render a collection of children, use an array instead.`

#### For QA:
<!-- Optional. Replace this comment with any necessary information needed by QA to test this Pull Request -->

#### Documentation:
<!-- Optional. Replace this comment with details helpful for writing the doc: overview, code snippets for extensibility etc. -->


<!-- 
Before you click submit:
    - Test the solution manually
    - Provide automated test coverage
    - Confirm that target branch is set correctly
    - For new features, confirm that you have suitable access control and injection prevention
    - Run PHP CS Fixer for new PHP code (use $ composer fix-cs)
    - Run ESLint and Prettier for new JS/SCSS code (use $ yarn fix)
    - Ask for a review (ping @ibexa/php-dev or @ibexa/javascript-dev depending on the changes) 
--> 
