### PR TITLE
IBX-9058: Complete REST API

### DIFF
--- a/src/bundle/ApiPlatform/OpenApiFactory.php
+++ b/src/bundle/ApiPlatform/OpenApiFactory.php
@@ -105,7 +105,7 @@ final readonly class OpenApiFactory implements OpenApiFactoryInterface
                 $exampleFilePath = $this->kernel->locateResource($responseContent['x-ibexa-example-file']);
                 $exampleFileContent = file_get_contents($exampleFilePath);
                 if ('json' === array_slice(explode('.', pathinfo($exampleFilePath, PATHINFO_FILENAME)), -1, 1)[0]) {
-                    $newContent[$mediaType]['example'] = json_decode($exampleFileContent, true);
+                    $newContent[$mediaType]['example'] = json_decode($exampleFileContent ?: '', true);
                 } else {
                     $newContent[$mediaType]['example'] = $exampleFileContent;
                 }

--- a/src/bundle/ApiPlatform/OpenApiFactory.php
+++ b/src/bundle/ApiPlatform/OpenApiFactory.php
@@ -104,11 +104,8 @@ final readonly class OpenApiFactory implements OpenApiFactoryInterface
 
                 $exampleFilePath = $this->kernel->locateResource($responseContent['x-ibexa-example-file']);
                 $exampleFileContent = file_get_contents($exampleFilePath);
-                if ('json' === array_slice(explode('.', pathinfo($exampleFilePath, PATHINFO_FILENAME)), -1, 1)[0]) {
-                    $newContent[$mediaType]['example'] = json_decode($exampleFileContent ?: '', true);
-                } else {
-                    $newContent[$mediaType]['example'] = $exampleFileContent;
-                }
+                $isJson = 'json' === array_slice(explode('.', pathinfo($exampleFilePath, PATHINFO_FILENAME)), -1, 1)[0];
+                $newContent[$mediaType]['example'] = $isJson ? json_decode($exampleFileContent ?: '', true) : $exampleFileContent;
                 unset($newContent[$mediaType]['x-ibexa-example-file']);
             }
 

--- a/src/bundle/ApiPlatform/OpenApiFactory.php
+++ b/src/bundle/ApiPlatform/OpenApiFactory.php
@@ -101,8 +101,11 @@ final readonly class OpenApiFactory implements OpenApiFactoryInterface
 
                 $exampleFilePath = $this->kernel->locateResource($responseContent['x-ibexa-example-file']);
                 $exampleFileContent = file_get_contents($exampleFilePath);
-
-                $newContent[$mediaType]['example'] = $exampleFileContent;
+                if ('json' === array_slice(explode('.', pathinfo($exampleFilePath, PATHINFO_FILENAME)), -1, 1)[0]) {
+                    $newContent[$mediaType]['example'] = json_decode($exampleFileContent, true);
+                } else {
+                    $newContent[$mediaType]['example'] = $exampleFileContent;
+                }
                 unset($newContent[$mediaType]['x-ibexa-example-file']);
             }
 

--- a/src/bundle/ApiPlatform/OpenApiFactory.php
+++ b/src/bundle/ApiPlatform/OpenApiFactory.php
@@ -105,7 +105,7 @@ final readonly class OpenApiFactory implements OpenApiFactoryInterface
                 $exampleFilePath = $this->kernel->locateResource($responseContent['x-ibexa-example-file']);
                 $exampleFileContent = file_get_contents($exampleFilePath);
                 $isJson = 'json' === array_slice(explode('.', pathinfo($exampleFilePath, PATHINFO_FILENAME)), -1, 1)[0];
-                $newContent[$mediaType]['example'] = $isJson ? json_decode($exampleFileContent ?: '', true) : $exampleFileContent;
+                $newContent[$mediaType]['example'] = $isJson ? json_decode($exampleFileContent ?: '', true, 512, JSON_THROW_ON_ERROR) : $exampleFileContent;
                 unset($newContent[$mediaType]['x-ibexa-example-file']);
             }
 

--- a/src/bundle/Resources/api_platform/schemas/views_schemas.yml
+++ b/src/bundle/Resources/api_platform/schemas/views_schemas.yml
@@ -81,6 +81,9 @@ schemas:
             performCount:
                 description: If true, search engine should perform count even if that means extra lookup.
                 type: boolean
+    LocationQuery:
+        description: This class is used to perform a Location query.
+        $ref: "#/components/schemas/Query"
     Criterion:
         description: Criterion implementations.
         type: object

--- a/src/lib/Server/Controller/User/UserListController.php
+++ b/src/lib/Server/Controller/User/UserListController.php
@@ -61,7 +61,7 @@ use Symfony\Component\HttpFoundation\Response;
                 ],
             ],
             Response::HTTP_NOT_FOUND => [
-                'description' => 'If there are no visibile Users matching the filter.',
+                'description' => 'If there are no visible Users matching the filter.',
             ],
         ],
     ),

--- a/src/lib/Server/Controller/User/UserVerifyController.php
+++ b/src/lib/Server/Controller/User/UserVerifyController.php
@@ -30,7 +30,7 @@ use Symfony\Component\HttpFoundation\Response;
                 'description' => 'OK - verifies if there are Users matching the given filter.',
             ],
             Response::HTTP_NOT_FOUND => [
-                'description' => 'Error - there are no visibile Users matching the filter.',
+                'description' => 'Error - there are no visible Users matching the filter.',
             ],
         ],
     ),


### PR DESCRIPTION
| :ticket: Issue | IBX-9058 |
|----------------|-----------|

#### Related PRs: 

- ibexa/segmentation#125
- ibexa/cart#124
- ibexa/documentation-developer#2674

#### Description:

- Fix JSON examples (see below)
- Add LocationQuery (which extend Query)
- Fix typo "visibile" → "visible"

##### About JSON examples

In Redocly output, while XML examples are OK, JSON examples are one-lined with `\n`. It seems that an object example should be a YAML object, not a single JSON string. I didn't find an `example:` example but this is how `examples:` works according to specifications and https://redocly.com/learn/openapi/openapi-visual-reference/example. The fix help to have JSON well interpreted in the Redocly output, an unfoldable object easier to navigate.

Before, without the fix:
![An hard to read single string (copy is OK)](https://github.com/user-attachments/assets/98da9172-f433-41b8-9c30-63da507bef09)

After, with the fix:
![An unfoldable object (copy is still OK)](https://github.com/user-attachments/assets/42d2e636-b28a-4983-ba73-b2170c1c8485)

#### For QA:
<!-- Optional. Replace this comment with any necessary information needed by QA to test this Pull Request -->

#### Documentation:
<!-- Optional. Replace this comment with details helpful for writing the doc: overview, code snippets for extensibility etc. -->


<!-- 
Before you click submit:
    - Test the solution manually
    - Provide automated test coverage
    - Confirm that target branch is set correctly
    - For new features, confirm that you have suitable access control and injection prevention
    - Run PHP CS Fixer for new PHP code (use $ composer fix-cs)
    - Run ESLint and Prettier for new JS/SCSS code (use $ yarn fix)
    - Ask for a review (ping @ibexa/php-dev or @ibexa/javascript-dev depending on the changes) 
--> 
