### PR TITLE
Fixed an issue when empty array was return instead of object

### DIFF
--- a/src/lib/Output/Normalizer/JsonObjectNormalizer.php
+++ b/src/lib/Output/Normalizer/JsonObjectNormalizer.php
@@ -18,16 +18,18 @@ use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
 
 final class JsonObjectNormalizer implements NormalizerInterface, NormalizerAwareInterface
 {
+    public const string PRESERVE_EMPTY_OBJECTS = 'preserve_empty_objects';
+
     use NormalizerAwareTrait;
 
     /**
      * @param array<mixed> $context
      *
-     * @return array<mixed>
+     * @return array<mixed>|\ArrayObject
      *
      * {@inheritDoc}
      */
-    public function normalize($object, ?string $format = null, array $context = []): array
+    public function normalize($object, ?string $format = null, array $context = []): array|\ArrayObject
     {
         $vars = get_object_vars($object);
 
@@ -57,6 +59,12 @@ final class JsonObjectNormalizer implements NormalizerInterface, NormalizerAware
                     : $this->normalizer->normalize($value, $format, $context)
                 ;
             }
+        }
+
+        $preserveEmptyObjects = $context[self::PRESERVE_EMPTY_OBJECTS] ?? false;
+
+        if ($preserveEmptyObjects && $data === []) {
+            return new NativeArrayObject();
         }
 
         return $data;


### PR DESCRIPTION
| :ticket: Issue | N/A |
|----------------|-----------|

 
#### Related PRs: 
- https://github.com/ibexa/connector-ai/pull/118


#### Description:
Currently, an empty array is returned instead of an object. AbstractObjectNormalizer in a similar case also returns ArrayObject
```
        if ($preserveEmptyObjects && !$data) {
            return new \ArrayObject();
        }

        return $data;
```
The issue is visible in https://github.com/ibexa/connector-ai/actions/runs/13882215491/job/38842242488.
The `preserve_empty_objects` flag will be set into context by `[src/lib/REST/Output/Normalizer/PreserveEmptyObjectNormalizer.php](https://github.com/ibexa/rest/pull/165/files#diff-252f4432e1b58cf174a022d3d3bc98a2462016cf7638fbc301c7791498cbee64)` 

#### For QA:
<!-- Optional. Replace this comment with any necessary information needed by QA to test this Pull Request -->

#### Documentation:
<!-- Optional. Replace this comment with details helpful for writing the doc: overview, code snippets for extensibility etc. -->


<!-- 
Before you click submit:
    - Test the solution manually
    - Provide automated test coverage
    - Confirm that target branch is set correctly
    - For new features, confirm that you have suitable access control and injection prevention
    - Run PHP CS Fixer for new PHP code (use $ composer fix-cs)
    - Run ESLint and Prettier for new JS/SCSS code (use $ yarn fix)
    - Ask for a review (ping @ibexa/php-dev or @ibexa/javascript-dev depending on the changes) 
--> 
