### PR TITLE
Moved ibexa_get_rest_csrf_token_intention twig function to ibexa/rest package

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -44,6 +44,7 @@
         "symfony/security-bundle": "^7.2",
         "symfony/security-csrf": "^7.2",
         "symfony/yaml": "^7.2",
+        "twig/twig": "^3.0",
         "webmozart/assert": "^1.11"
     },
     "require-dev": {

--- a/src/bundle/DependencyInjection/IbexaRestExtension.php
+++ b/src/bundle/DependencyInjection/IbexaRestExtension.php
@@ -50,6 +50,7 @@ class IbexaRestExtension extends ConfigurableExtension implements PrependExtensi
         $loader->load('security.yml');
         $loader->load('default_settings.yml');
         $loader->load('serializer.yaml');
+        $loader->load('twig.yaml');
 
         $processor = new ConfigurationProcessor($container, 'ibexa.site_access.config');
         $processor->mapConfigArray('rest_root_resources', $mergedConfig);

--- a/src/bundle/Resources/config/twig.yaml
+++ b/src/bundle/Resources/config/twig.yaml
@@ -1,0 +1,11 @@
+services:
+    _defaults:
+        autowire: true
+        autoconfigure: true
+        public: false
+
+    Ibexa\Bundle\Rest\Twig\SecurityExtension:
+        arguments:
+            $csrfTokenIntention: '%ibexa.rest.csrf_token_intention%'
+        tags:
+            - { name: twig.extension }

--- a/src/bundle/Twig/SecurityExtension.php
+++ b/src/bundle/Twig/SecurityExtension.php
@@ -1,0 +1,30 @@
+<?php
+
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace Ibexa\Bundle\Rest\Twig;
+
+use Twig\Extension\AbstractExtension;
+use Twig\TwigFunction;
+
+final class SecurityExtension extends AbstractExtension
+{
+    public function __construct(
+        private readonly string $csrfTokenIntention,
+    ) {
+    }
+
+    public function getFunctions(): array
+    {
+        return [
+            new TwigFunction(
+                'ibexa_get_rest_csrf_token_intention',
+                fn (): string => $this->csrfTokenIntention,
+            ),
+        ];
+    }
+}

--- a/tests/bundle/Twig/SecurityExtensionTest.php
+++ b/tests/bundle/Twig/SecurityExtensionTest.php
@@ -1,0 +1,29 @@
+<?php
+
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace Ibexa\Tests\Bundle\Rest\Twig;
+
+use Ibexa\Bundle\Rest\Twig\SecurityExtension;
+use Twig\Test\IntegrationTestCase;
+
+final class SecurityExtensionTest extends IntegrationTestCase
+{
+    private const string CSRF_TOKEN_INTENTION = 'foo_intention';
+
+    protected function getExtensions(): array
+    {
+        return [
+            new SecurityExtension(self::CSRF_TOKEN_INTENTION),
+        ];
+    }
+
+    protected function getFixturesDir(): string
+    {
+        return __DIR__ . '/_fixtures/security/';
+    }
+}

--- a/tests/bundle/Twig/_fixtures/security/ibexa_get_rest_csrf_token_intention.test
+++ b/tests/bundle/Twig/_fixtures/security/ibexa_get_rest_csrf_token_intention.test
@@ -1,0 +1,8 @@
+--TEST--
+"ibexa_get_rest_csrf_token_intention" function
+--TEMPLATE--
+{{ ibexa_get_rest_csrf_token_intention() }}
+--DATA--
+return [];
+--EXPECT--
+foo_intention


### PR DESCRIPTION
| :ticket: Issue | N/A       |
|----------------|-----------|

<!-- 
#### Related PRs: 
- https://github.com/ibexa/core/pull/1
-->

#### Description:
`ibexa_get_rest_csrf_token_intention` function is needed in both `ibexa/admin-ui` and `ibexa/storefront` packages.


#### For QA:
N/A

#### Documentation:
N/A


<!-- 
Before you click submit:
    - Test the solution manually
    - Provide automated test coverage
    - Confirm that target branch is set correctly
    - For new features, confirm that you have suitable access control and injection prevention
    - Run PHP CS Fixer for new PHP code (use $ composer fix-cs)
    - Run ESLint and Prettier for new JS/SCSS code (use $ yarn fix)
    - Ask for a review (ping @ibexa/php-dev or @ibexa/javascript-dev depending on the changes) 
--> 
