### PR TITLE
IBX-10254: Renamed ez_lock object state group to ibexa_lock

### DIFF
--- a/tests/bundle/Functional/SearchView/Criterion/ObjectStateIdentifierTest.php
+++ b/tests/bundle/Functional/SearchView/Criterion/ObjectStateIdentifierTest.php
@@ -17,7 +17,7 @@ final class ObjectStateIdentifierTest extends SearchCriterionTestCase
         return [
             'identifier with target group' => [
                 'json',
-                $this->buildJsonCriterionQuery('"ObjectStateIdentifierCriterion": {"value": "not_locked", "target": "ez_lock"}'),
+                $this->buildJsonCriterionQuery('"ObjectStateIdentifierCriterion": {"value": "not_locked", "target": "ibexa_lock"}'),
                 16,
             ],
             'identifier without target group' => [


### PR DESCRIPTION
| :ticket: Issue | IBX-10254 |
|----------------|-----------|

<!-- 
#### Related PRs: 
- https://github.com/ibexa/core/pull/1
-->

#### Description:
Renamed `ez_lock` object state group to `ibexa_lock`. This change doesn't not affect existing projects. 

#### For QA:
N/A

#### Documentation:
Replace `ez_lock` mentions.

<!-- 
Before you click submit:
    - Test the solution manually
    - Provide automated test coverage
    - Confirm that target branch is set correctly
    - For new features, confirm that you have suitable access control and injection prevention
    - Run PHP CS Fixer for new PHP code (use $ composer fix-cs)
    - Run ESLint and Prettier for new JS/SCSS code (use $ yarn fix)
    - Ask for a review (ping @ibexa/php-dev or @ibexa/javascript-dev depending on the changes) 
--> 
