### PR TITLE
Allowed interfaces as handled visitor FQCNs

### DIFF
--- a/src/contracts/Output/ValueObjectVisitorDispatcher.php
+++ b/src/contracts/Output/ValueObjectVisitorDispatcher.php
@@ -75,6 +75,13 @@ class ValueObjectVisitorDispatcher
             }
         } while ($className = get_parent_class($className));
 
+        $className = class_implements($data);
+        foreach ($className as $interface) {
+            if (isset($this->visitors[$interface])) {
+                return $this->visitors[$interface]->visit($this->outputVisitor, $this->outputGenerator, $data);
+            }
+        }
+
         throw new Exceptions\NoVisitorFoundException($checkedClassNames);
     }
 }

--- a/tests/lib/Output/ValueObjectInterface.php
+++ b/tests/lib/Output/ValueObjectInterface.php
@@ -6,13 +6,9 @@
  */
 namespace Ibexa\Tests\Rest\Output;
 
-use stdClass;
-
 /**
- * Test dummy class.
+ * Test dummy interface.
  */
-class ValueObject extends stdClass implements ValueObjectInterface
+interface ValueObjectInterface
 {
 }
-
-class_alias(ValueObject::class, 'EzSystems\EzPlatformRest\Tests\Output\ValueObject');

--- a/tests/lib/Output/ValueObjectVisitorDispatcherTest.php
+++ b/tests/lib/Output/ValueObjectVisitorDispatcherTest.php
@@ -79,6 +79,22 @@ class ValueObjectVisitorDispatcherTest extends TestCase
         $dispatcher->visit($data);
     }
 
+    public function testVisitInterface(): void
+    {
+        $data = new ValueObject();
+
+        $valueObjectVisitor = $this->getValueObjectVisitorMock();
+        $valueObjectVisitor
+            ->expects(self::once())
+            ->method('visit')
+            ->with($this->getOutputVisitorMock(), $this->getOutputGeneratorMock(), $data);
+
+        $dispatcher = $this->getValueObjectDispatcher();
+        $dispatcher->addVisitor(ValueObjectInterface::class, $valueObjectVisitor);
+
+        $dispatcher->visit($data);
+    }
+
     public function testVisitValueObjectSecondRuleParentMatch()
     {
         $data = new ValueObject();


### PR DESCRIPTION
| :ticket: Issue | IBX-XXXXX |
|----------------|-----------|

<!-- 
#### Related PRs: 
- https://github.com/ibexa/core/pull/1
-->

#### Description:
This will allow a following service declaration change:
```yaml
    Ibexa\Discounts\REST\Output\ValueObjectVisitor\DiscountExpressionAware:
        parent: Ibexa\Contracts\Rest\Output\ValueObjectVisitor
        autowire: true
        tags:
# This can now be removed - { name: ibexa.rest.output.value_object.visitor, type: Ibexa\Discounts\Value\AbstractDiscountExpressionAware }
            - { name: ibexa.rest.output.value_object.visitor, type: Ibexa\Contracts\Discounts\Value\DiscountRuleInterface }
            - { name: ibexa.rest.output.value_object.visitor, type: Ibexa\Contracts\Discounts\Value\DiscountConditionInterface }
```

#### For QA:
<!-- Optional. Replace this comment with any necessary information needed by QA to test this Pull Request -->

#### Documentation:
<!-- Optional. Replace this comment with details helpful for writing the doc: overview, code snippets for extensibility etc. -->


<!-- 
Before you click submit:
    - Test the solution manually
    - Provide automated test coverage
    - Confirm that target branch is set correctly
    - For new features, confirm that you have suitable access control and injection prevention
    - Run PHP CS Fixer for new PHP code (use $ composer fix-cs)
    - Run ESLint and Prettier for new JS/SCSS code (use $ yarn fix)
    - Ask for a review (ping @ibexa/php-dev or @ibexa/javascript-dev depending on the changes) 
--> 
