### PR TITLE
Added cast to `int` when trying to load a location in Location redirect controller

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1693,12 +1693,6 @@ parameters:
 			path: src/lib/Server/Controller/Location.php
 
 		-
-			message: '#^Parameter \#1 \$locationId of method Ibexa\\Contracts\\Core\\Repository\\LocationService\:\:loadLocation\(\) expects int, string\|null given\.$#'
-			identifier: argument.type
-			count: 1
-			path: src/lib/Server/Controller/Location.php
-
-		-
 			message: '#^Parameter \#1 \$remoteId of method Ibexa\\Contracts\\Core\\Repository\\LocationService\:\:loadLocationByRemoteId\(\) expects string, string\|null given\.$#'
 			identifier: argument.type
 			count: 2

--- a/src/lib/Server/Controller/Location.php
+++ b/src/lib/Server/Controller/Location.php
@@ -83,12 +83,12 @@ class Location extends RestController
     public function redirectLocation(Request $request)
     {
         if ($request->query->has('id')) {
-            $location = $this->locationService->loadLocation($request->query->get('id'));
+            $location = $this->locationService->loadLocation($request->query->getInt('id'));
         } elseif ($request->query->has('remoteId')) {
             $location = $this->locationService->loadLocationByRemoteId($request->query->get('remoteId'));
         } elseif ($request->query->has('urlAlias')) {
             $urlAlias = $this->urlAliasService->lookup($request->query->get('urlAlias'));
-            $location = $this->locationService->loadLocation($urlAlias->destination);
+            $location = $this->locationService->loadLocation((int)$urlAlias->destination);
         } else {
             throw new BadRequestException("At least one of 'id', 'remoteId' or 'urlAlias' parameters is required.");
         }


### PR DESCRIPTION
| :ticket: Issue | n/a |
|----------------|-----|


#### Description:

New day, new PHPStan release. Uncovered a potentially fatal error when strict types are enforced in Location redirect controller. [Visible on 5.0.x-dev](https://github.com/ibexa/rest/actions/runs/17797131143/job/50587324689?pr=197#step:5:18), but exists on 4.6. Seems for some reason on 5.0.x-dev the issue was not detected after refactoring controllers. 

Fixed on 4.6 instead of re-adding to the baseline on main.