### PR TITLE
IBX-10396: Added support for x-ibexa-example-file in request files

### DIFF
--- a/src/bundle/ApiPlatform/OpenApiFactory.php
+++ b/src/bundle/ApiPlatform/OpenApiFactory.php
@@ -220,6 +220,9 @@ final readonly class OpenApiFactory implements OpenApiFactoryInterface
         return 'json' === array_slice(explode('.', pathinfo($filePath, PATHINFO_FILENAME)), -1, 1)[0];
     }
 
+    /** 
+     * @return array<string, mixed>
+     */
     private function parseJsonFile(string $fileContent, string $filePath): array
     {
         try {

--- a/src/bundle/ApiPlatform/OpenApiFactory.php
+++ b/src/bundle/ApiPlatform/OpenApiFactory.php
@@ -220,7 +220,7 @@ final readonly class OpenApiFactory implements OpenApiFactoryInterface
         return 'json' === array_slice(explode('.', pathinfo($filePath, PATHINFO_FILENAME)), -1, 1)[0];
     }
 
-    /** 
+    /**
      * @return array<string, mixed>
      */
     private function parseJsonFile(string $fileContent, string $filePath): array

--- a/src/bundle/ApiPlatform/OpenApiFactory.php
+++ b/src/bundle/ApiPlatform/OpenApiFactory.php
@@ -156,7 +156,9 @@ final readonly class OpenApiFactory implements OpenApiFactoryInterface
             $isJson = $this->isJson($exampleFilePath);
 
             $newRequestContent = $requestContent;
-            $newRequestContent['example'] = $isJson ? json_decode($exampleFileContent, true, 512, JSON_THROW_ON_ERROR) : $exampleFileContent;
+            $newRequestContent['example'] = $isJson === true
+                ? json_decode($exampleFileContent, true, 512, JSON_THROW_ON_ERROR)
+                : $exampleFileContent;
             unset($newRequestContent['x-ibexa-example-file']);
 
             $newContent[$mediaType] = $newRequestContent;

--- a/src/bundle/ApiPlatform/OpenApiFactory.php
+++ b/src/bundle/ApiPlatform/OpenApiFactory.php
@@ -226,7 +226,7 @@ final readonly class OpenApiFactory implements OpenApiFactoryInterface
 
     private function isJson(string $filePath): bool
     {
-        return 'json' === array_slice(explode('.', pathinfo($filePath, PATHINFO_FILENAME)), -1, 1)[0];
+        return in_array('json', explode('.', pathinfo($filePath, PATHINFO_FILENAME));
     }
 
     /**

--- a/src/bundle/ApiPlatform/OpenApiFactory.php
+++ b/src/bundle/ApiPlatform/OpenApiFactory.php
@@ -147,18 +147,10 @@ final readonly class OpenApiFactory implements OpenApiFactoryInterface
             }
 
             $exampleFilePath = $this->kernel->locateResource($requestContent['x-ibexa-example-file']);
-            $exampleFileContent = file_get_contents($exampleFilePath);
-
-            if ($exampleFileContent === false) {
-                throw new \RuntimeException("Failed to read example file: {$exampleFilePath}");
-            }
-
-            $isJson = $this->isJson($exampleFilePath);
+            $example = $this->loadExampleFromFile($exampleFilePath);
 
             $newRequestContent = $requestContent;
-            $newRequestContent['example'] = $isJson === true
-                ? $this->parseJsonFile($exampleFileContent, $exampleFilePath)
-                : $exampleFileContent;
+            $newRequestContent['example'] = $example;
             unset($newRequestContent['x-ibexa-example-file']);
 
             $newContent[$mediaType] = $newRequestContent;
@@ -198,9 +190,8 @@ final readonly class OpenApiFactory implements OpenApiFactoryInterface
                 }
 
                 $exampleFilePath = $this->kernel->locateResource($responseContent['x-ibexa-example-file']);
-                $exampleFileContent = file_get_contents($exampleFilePath);
-                $isJson = $this->isJson($exampleFilePath);
-                $newContent[$mediaType]['example'] = $isJson === true ? $this->parseJsonFile($exampleFileContent ?: '', $exampleFilePath) : $exampleFileContent;
+                $example = $this->loadExampleFromFile($exampleFilePath);
+                $newContent[$mediaType]['example'] = $example;
                 unset($newContent[$mediaType]['x-ibexa-example-file']);
             }
 
@@ -213,6 +204,24 @@ final readonly class OpenApiFactory implements OpenApiFactoryInterface
         }
 
         return $newOperation;
+    }
+
+    /**
+     * @return array<string, mixed>|string
+     *
+     * @throws \JsonException
+     */
+    private function loadExampleFromFile(string $filePath): array|string
+    {
+        $fileContent = file_get_contents($filePath);
+
+        if ($fileContent === false) {
+            throw new \RuntimeException("Failed to read example file: {$filePath}");
+        }
+
+        return $this->isJson($filePath)
+            ? $this->parseJsonFile($fileContent, $filePath)
+            : $fileContent;
     }
 
     private function isJson(string $filePath): bool

--- a/src/bundle/ApiPlatform/OpenApiFactory.php
+++ b/src/bundle/ApiPlatform/OpenApiFactory.php
@@ -226,7 +226,7 @@ final readonly class OpenApiFactory implements OpenApiFactoryInterface
 
     private function isJson(string $filePath): bool
     {
-        return in_array('json', explode('.', pathinfo($filePath, PATHINFO_FILENAME));
+        return in_array('json', explode('.', pathinfo($filePath, PATHINFO_FILENAME)));
     }
 
     /**

--- a/src/bundle/ApiPlatform/OpenApiFactory.php
+++ b/src/bundle/ApiPlatform/OpenApiFactory.php
@@ -165,7 +165,7 @@ final readonly class OpenApiFactory implements OpenApiFactoryInterface
             $hasChanges = true;
         }
 
-        if ($hasChanges) {
+        if ($hasChanges === true) {
             $newRequestBody = new RequestBody(
                 $requestBody->getDescription(),
                 $newContent,

--- a/src/bundle/ApiPlatform/OpenApiFactory.php
+++ b/src/bundle/ApiPlatform/OpenApiFactory.php
@@ -157,7 +157,7 @@ final readonly class OpenApiFactory implements OpenApiFactoryInterface
 
             $newRequestContent = $requestContent;
             $newRequestContent['example'] = $isJson === true
-                ? json_decode($exampleFileContent, true, 512, JSON_THROW_ON_ERROR)
+                ? $this->parseJsonFile($exampleFileContent, $exampleFilePath)
                 : $exampleFileContent;
             unset($newRequestContent['x-ibexa-example-file']);
 
@@ -200,7 +200,7 @@ final readonly class OpenApiFactory implements OpenApiFactoryInterface
                 $exampleFilePath = $this->kernel->locateResource($responseContent['x-ibexa-example-file']);
                 $exampleFileContent = file_get_contents($exampleFilePath);
                 $isJson = $this->isJson($exampleFilePath);
-                $newContent[$mediaType]['example'] = $isJson ? json_decode($exampleFileContent ?: '', true, 512, JSON_THROW_ON_ERROR) : $exampleFileContent;
+                $newContent[$mediaType]['example'] = $isJson === true ? $this->parseJsonFile($exampleFileContent ?: '', $exampleFilePath) : $exampleFileContent;
                 unset($newContent[$mediaType]['x-ibexa-example-file']);
             }
 
@@ -218,5 +218,14 @@ final readonly class OpenApiFactory implements OpenApiFactoryInterface
     private function isJson(string $filePath): bool
     {
         return 'json' === array_slice(explode('.', pathinfo($filePath, PATHINFO_FILENAME)), -1, 1)[0];
+    }
+
+    private function parseJsonFile(string $fileContent, string $filePath): array
+    {
+        try {
+            return json_decode($fileContent, true, 512, JSON_THROW_ON_ERROR);
+        } catch (\JsonException $e) {
+            throw new \RuntimeException("Failed to parse JSON example file: {$filePath}", 0, $e);
+        }
     }
 }

--- a/tests/bundle/ApiPlatform/Fixtures/examples/test-request.json.example
+++ b/tests/bundle/ApiPlatform/Fixtures/examples/test-request.json.example
@@ -1,0 +1,4 @@
+{
+    "username": "admin",
+    "password": "secret"
+}

--- a/tests/bundle/ApiPlatform/Fixtures/examples/test-request.xml.example
+++ b/tests/bundle/ApiPlatform/Fixtures/examples/test-request.xml.example
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<LoginRequest>
+    <username>admin</username>
+    <password>secret</password>
+</LoginRequest>

--- a/tests/bundle/ApiPlatform/Fixtures/examples/test-response.json.example
+++ b/tests/bundle/ApiPlatform/Fixtures/examples/test-response.json.example
@@ -1,0 +1,7 @@
+{
+    "token": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9",
+    "user": {
+        "id": 14,
+        "login": "admin"
+    }
+}

--- a/tests/bundle/ApiPlatform/Fixtures/examples/test-response.xml.example
+++ b/tests/bundle/ApiPlatform/Fixtures/examples/test-response.xml.example
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Session>
+    <identifier>go327ij2cirpo59pb6rrv2a4el2</identifier>
+    <name>eZSESSID</name>
+    <csrfToken>23lkneri34ijajedfw39orj3j93</csrfToken>
+</Session>

--- a/tests/bundle/ApiPlatform/OpenApiFactoryTest.php
+++ b/tests/bundle/ApiPlatform/OpenApiFactoryTest.php
@@ -1,0 +1,406 @@
+<?php
+
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace Ibexa\Tests\Bundle\Rest\ApiPlatform;
+
+use ApiPlatform\OpenApi\Factory\OpenApiFactoryInterface;
+use ApiPlatform\OpenApi\Model\Info;
+use ApiPlatform\OpenApi\Model\Operation;
+use ApiPlatform\OpenApi\Model\PathItem;
+use ApiPlatform\OpenApi\Model\Paths;
+use ApiPlatform\OpenApi\Model\RequestBody;
+use ApiPlatform\OpenApi\OpenApi;
+use ArrayObject;
+use Ibexa\Bundle\Rest\ApiPlatform\EditionBadge\EditionBadgeFactoryInterface;
+use Ibexa\Bundle\Rest\ApiPlatform\OpenApiFactory;
+use Ibexa\Bundle\Rest\ApiPlatform\SchemasCollectionFactory;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpKernel\KernelInterface;
+
+/**
+ * @covers \Ibexa\Bundle\Rest\ApiPlatform\OpenApiFactory
+ */
+final class OpenApiFactoryTest extends TestCase
+{
+    private const EXAMPLE_REQUEST_FILE = __DIR__ . '/Fixtures/examples/test-request.json.example';
+    private const EXAMPLE_REQUEST_XML_FILE = __DIR__ . '/Fixtures/examples/test-request.xml.example';
+    private const EXAMPLE_RESPONSE_JSON_FILE = __DIR__ . '/Fixtures/examples/test-response.json.example';
+    private const EXAMPLE_RESPONSE_XML_FILE = __DIR__ . '/Fixtures/examples/test-response.xml.example';
+
+    private OpenApiFactory $factory;
+
+    /** @var \ApiPlatform\OpenApi\Factory\OpenApiFactoryInterface&\PHPUnit\Framework\MockObject\MockObject */
+    private OpenApiFactoryInterface $decoratedFactory;
+
+    private KernelInterface $kernel;
+
+    protected function setUp(): void
+    {
+        $this->decoratedFactory = $this->getDecoratedFactoryMock();
+        $schemasCollectionFactory = new SchemasCollectionFactory();
+        $this->kernel = $this->getKernelMock();
+        $editionBadgeFactory = $this->getEditionBadgeFactoryMock();
+
+        $this->factory = new OpenApiFactory(
+            $this->decoratedFactory,
+            $schemasCollectionFactory,
+            $this->kernel,
+            $editionBadgeFactory,
+            '/api/ibexa/v2'
+        );
+    }
+
+    public function testInjectsJsonRequestExampleFromFile(): void
+    {
+        // Given: An operation with x-ibexa-example-file in request body
+        $requestBody = new RequestBody(
+            description: 'Login request',
+            content: new ArrayObject([
+                'application/json' => [
+                    'schema' => ['$ref' => '#/components/schemas/LoginRequest'],
+                    'x-ibexa-example-file' => '@TestBundle/examples/request.json',
+                ],
+            ])
+        );
+
+        $operation = new Operation(
+            requestBody: $requestBody,
+            responses: [
+                '200' => ['description' => 'Success'],
+            ]
+        );
+
+        $paths = new Paths();
+        $paths->addPath('/test', new PathItem(post: $operation));
+
+        $openApi = new OpenApi(
+            info: new Info(title: 'Test API', version: '1.0'),
+            servers: [],
+            paths: $paths
+        );
+
+        $this->decoratedFactory
+            ->expects(self::once())
+            ->method('__invoke')
+            ->willReturn($openApi);
+
+        // When: Factory processes the OpenAPI spec
+        $result = ($this->factory)([]);
+
+        // Then: The request example is injected from file
+        $processedPath = $result->getPaths()->getPath('/test');
+        self::assertNotNull($processedPath);
+        $processedOperation = $processedPath->getPost();
+        self::assertNotNull($processedOperation);
+        $processedRequestBody = $processedOperation->getRequestBody();
+
+        self::assertNotNull($processedRequestBody);
+        $content = $processedRequestBody->getContent();
+        self::assertNotNull($content);
+
+        $jsonContent = $content['application/json'];
+
+        // Example should be injected
+        self::assertArrayHasKey('example', $jsonContent);
+        self::assertEquals([
+            'username' => 'admin',
+            'password' => 'secret',
+        ], $jsonContent['example']);
+
+        // x-ibexa-example-file should be removed
+        self::assertArrayNotHasKey('x-ibexa-example-file', $jsonContent);
+    }
+
+    public function testInjectsXmlRequestExampleFromFile(): void
+    {
+        // Given: An operation with XML request example
+        $requestBody = new RequestBody(
+            description: 'Login request',
+            content: new ArrayObject([
+                'application/xml' => [
+                    'schema' => ['$ref' => '#/components/schemas/LoginRequest'],
+                    'x-ibexa-example-file' => '@TestBundle/examples/request.xml',
+                ],
+            ])
+        );
+
+        $operation = new Operation(
+            requestBody: $requestBody,
+            responses: [
+                '200' => ['description' => 'Success'],
+            ]
+        );
+
+        $paths = new Paths();
+        $paths->addPath('/test', new PathItem(post: $operation));
+
+        $openApi = new OpenApi(
+            info: new Info(title: 'Test API', version: '1.0'),
+            servers: [],
+            paths: $paths
+        );
+
+        $this->decoratedFactory
+            ->expects(self::once())
+            ->method('__invoke')
+            ->willReturn($openApi);
+
+        // When: Factory processes the OpenAPI spec
+        $result = ($this->factory)([]);
+
+        // Then: The XML request example is injected as string
+        $processedPath = $result->getPaths()->getPath('/test');
+        self::assertNotNull($processedPath);
+        $processedOperation = $processedPath->getPost();
+        self::assertNotNull($processedOperation);
+        $processedRequestBody = $processedOperation->getRequestBody();
+
+        self::assertNotNull($processedRequestBody);
+        $content = $processedRequestBody->getContent();
+        self::assertNotNull($content);
+
+        $xmlContent = $content['application/xml'];
+
+        // Example should be injected as string
+        self::assertArrayHasKey('example', $xmlContent);
+        self::assertIsString($xmlContent['example']);
+        self::assertStringContainsString('<LoginRequest>', $xmlContent['example']);
+        self::assertStringContainsString('<username>admin</username>', $xmlContent['example']);
+
+        // x-ibexa-example-file should be removed
+        self::assertArrayNotHasKey('x-ibexa-example-file', $xmlContent);
+    }
+
+    public function testInjectsMultipleMediaTypeRequestExamples(): void
+    {
+        // Given: An operation with both JSON and XML request examples
+        $requestBody = new RequestBody(
+            description: 'Login request',
+            content: new ArrayObject([
+                'application/json' => [
+                    'schema' => ['$ref' => '#/components/schemas/LoginRequest'],
+                    'x-ibexa-example-file' => '@TestBundle/examples/request.json',
+                ],
+                'application/xml' => [
+                    'schema' => ['$ref' => '#/components/schemas/LoginRequest'],
+                    'x-ibexa-example-file' => '@TestBundle/examples/request.xml',
+                ],
+            ])
+        );
+
+        $operation = new Operation(
+            requestBody: $requestBody,
+            responses: [
+                '200' => ['description' => 'Success'],
+            ]
+        );
+
+        $paths = new Paths();
+        $paths->addPath('/test', new PathItem(post: $operation));
+
+        $openApi = new OpenApi(
+            info: new Info(title: 'Test API', version: '1.0'),
+            servers: [],
+            paths: $paths
+        );
+
+        $this->decoratedFactory
+            ->expects(self::once())
+            ->method('__invoke')
+            ->willReturn($openApi);
+
+        // When: Factory processes the OpenAPI spec
+        $result = ($this->factory)([]);
+
+        // Then: Both examples are injected correctly
+        $processedRequestBody = $result->getPaths()->getPath('/test')?->getPost()?->getRequestBody();
+
+        self::assertNotNull($processedRequestBody);
+        $content = $processedRequestBody->getContent();
+        self::assertNotNull($content);
+
+        // Verify JSON example
+        $jsonContent = $content['application/json'];
+        self::assertArrayHasKey('example', $jsonContent);
+        self::assertEquals([
+            'username' => 'admin',
+            'password' => 'secret',
+        ], $jsonContent['example']);
+        self::assertArrayNotHasKey('x-ibexa-example-file', $jsonContent);
+
+        // Verify XML example
+        $xmlContent = $content['application/xml'];
+        self::assertArrayHasKey('example', $xmlContent);
+        self::assertIsString($xmlContent['example']);
+        self::assertStringContainsString('<LoginRequest>', $xmlContent['example']);
+        self::assertArrayNotHasKey('x-ibexa-example-file', $xmlContent);
+    }
+
+    public function testThrowsExceptionWhenRequestExampleFileNotFound(): void
+    {
+        // Given: An operation with invalid request example file path
+        $requestBody = new RequestBody(
+            description: 'Login request',
+            content: new ArrayObject([
+                'application/json' => [
+                    'schema' => ['$ref' => '#/components/schemas/LoginRequest'],
+                    'x-ibexa-example-file' => '@TestBundle/examples/non-existent.json',
+                ],
+            ])
+        );
+
+        $operation = new Operation(
+            requestBody: $requestBody,
+            responses: [
+                '200' => ['description' => 'Success'],
+            ]
+        );
+
+        $paths = new Paths();
+        $paths->addPath('/test', new PathItem(post: $operation));
+
+        $openApi = new OpenApi(
+            info: new Info(title: 'Test API', version: '1.0'),
+            servers: [],
+            paths: $paths
+        );
+
+        $this->decoratedFactory
+            ->expects(self::once())
+            ->method('__invoke')
+            ->willReturn($openApi);
+
+        // Then: Exception is thrown for non-existent file
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Unknown resource: @TestBundle/examples/non-existent.json');
+
+        // When: Factory processes the OpenAPI spec
+        ($this->factory)([]);
+    }
+
+    public function testThrowsExceptionWhenRequestExampleJsonIsInvalid(): void
+    {
+        // Create a temporary invalid JSON file
+        $invalidJsonFile = __DIR__ . '/Fixtures/examples/invalid.json.example';
+        file_put_contents($invalidJsonFile, '{invalid json}');
+
+        try {
+            // Update kernel mock to include the invalid file
+            $kernel = $this->getKernelMockWithCustomResourceMap([
+                '@TestBundle/examples/invalid.json' => $invalidJsonFile,
+            ]);
+
+            $factory = new OpenApiFactory(
+                $this->decoratedFactory,
+                new SchemasCollectionFactory(),
+                $kernel,
+                $this->getEditionBadgeFactoryMock(),
+                '/api/ibexa/v2'
+            );
+
+            // Given: An operation with invalid JSON example file
+            $requestBody = new RequestBody(
+                description: 'Login request',
+                content: new ArrayObject([
+                    'application/json' => [
+                        'schema' => ['$ref' => '#/components/schemas/LoginRequest'],
+                        'x-ibexa-example-file' => '@TestBundle/examples/invalid.json',
+                    ],
+                ])
+            );
+
+            $operation = new Operation(
+                requestBody: $requestBody,
+                responses: [
+                    '200' => ['description' => 'Success'],
+                ]
+            );
+
+            $paths = new Paths();
+            $paths->addPath('/test', new PathItem(post: $operation));
+
+            $openApi = new OpenApi(
+                info: new Info(title: 'Test API', version: '1.0'),
+                servers: [],
+                paths: $paths
+            );
+
+            $this->decoratedFactory
+                ->expects(self::once())
+                ->method('__invoke')
+                ->willReturn($openApi);
+
+            // Then: JsonException is thrown for invalid JSON
+            $this->expectException(\JsonException::class);
+
+            // When: Factory processes the OpenAPI spec
+            $factory([]);
+        } finally {
+            // Cleanup
+            if (file_exists($invalidJsonFile)) {
+                unlink($invalidJsonFile);
+            }
+        }
+    }
+
+    private function getDecoratedFactoryMock(): OpenApiFactoryInterface&MockObject
+    {
+        return $this->createMock(OpenApiFactoryInterface::class);
+    }
+
+    private function getKernelMock(): KernelInterface&MockObject
+    {
+        $kernelMock = $this->createMock(KernelInterface::class);
+
+        $kernelMock
+            ->method('locateResource')
+            ->willReturnCallback(static function (string $path) {
+                return match ($path) {
+                    '@TestBundle/examples/request.json' => self::EXAMPLE_REQUEST_FILE,
+                    '@TestBundle/examples/request.xml' => self::EXAMPLE_REQUEST_XML_FILE,
+                    '@TestBundle/examples/response.json' => self::EXAMPLE_RESPONSE_JSON_FILE,
+                    '@TestBundle/examples/response.xml' => self::EXAMPLE_RESPONSE_XML_FILE,
+                    default => throw new \InvalidArgumentException("Unknown resource: $path"),
+                };
+            });
+
+        return $kernelMock;
+    }
+
+    private function getEditionBadgeFactoryMock(): EditionBadgeFactoryInterface&MockObject
+    {
+        $editionBadgeFactoryMock = $this->createMock(EditionBadgeFactoryInterface::class);
+
+        $editionBadgeFactoryMock
+            ->method('getBadgesForOperation')
+            ->willReturn([]);
+
+        return $editionBadgeFactoryMock;
+    }
+
+    /**
+     * @param array<string, string> $resourceMap
+     */
+    private function getKernelMockWithCustomResourceMap(array $resourceMap): KernelInterface&MockObject
+    {
+        $kernelMock = $this->createMock(KernelInterface::class);
+
+        $kernelMock
+            ->method('locateResource')
+            ->willReturnCallback(static function (string $path) use ($resourceMap) {
+                if (isset($resourceMap[$path])) {
+                    return $resourceMap[$path];
+                }
+
+                throw new \InvalidArgumentException("Unknown resource: $path");
+            });
+
+        return $kernelMock;
+    }
+}

--- a/tests/bundle/ApiPlatform/OpenApiFactoryTest.php
+++ b/tests/bundle/ApiPlatform/OpenApiFactoryTest.php
@@ -335,8 +335,9 @@ final class OpenApiFactoryTest extends TestCase
                 ->method('__invoke')
                 ->willReturn($openApi);
 
-            // Then: JsonException is thrown for invalid JSON
-            $this->expectException(\JsonException::class);
+            // Then: RuntimeException is thrown for invalid JSON
+            $this->expectException(\RuntimeException::class);
+            $this->expectExceptionMessage("Failed to parse JSON example file: {$invalidJsonFile}");
 
             // When: Factory processes the OpenAPI spec
             $factory([]);

--- a/tests/bundle/ApiPlatform/OpenApiFactoryTest.php
+++ b/tests/bundle/ApiPlatform/OpenApiFactoryTest.php
@@ -28,15 +28,14 @@ use Symfony\Component\HttpKernel\KernelInterface;
  */
 final class OpenApiFactoryTest extends TestCase
 {
-    private const EXAMPLE_REQUEST_FILE = __DIR__ . '/Fixtures/examples/test-request.json.example';
-    private const EXAMPLE_REQUEST_XML_FILE = __DIR__ . '/Fixtures/examples/test-request.xml.example';
-    private const EXAMPLE_RESPONSE_JSON_FILE = __DIR__ . '/Fixtures/examples/test-response.json.example';
-    private const EXAMPLE_RESPONSE_XML_FILE = __DIR__ . '/Fixtures/examples/test-response.xml.example';
+    private const string EXAMPLE_REQUEST_FILE = __DIR__ . '/Fixtures/examples/test-request.json.example';
+    private const string EXAMPLE_REQUEST_XML_FILE = __DIR__ . '/Fixtures/examples/test-request.xml.example';
+    private const string EXAMPLE_RESPONSE_JSON_FILE = __DIR__ . '/Fixtures/examples/test-response.json.example';
+    private const string EXAMPLE_RESPONSE_XML_FILE = __DIR__ . '/Fixtures/examples/test-response.xml.example';
 
     private OpenApiFactory $factory;
 
-    /** @var \ApiPlatform\OpenApi\Factory\OpenApiFactoryInterface&\PHPUnit\Framework\MockObject\MockObject */
-    private OpenApiFactoryInterface $decoratedFactory;
+    private OpenApiFactoryInterface&MockObject $decoratedFactory;
 
     private KernelInterface $kernel;
 
@@ -360,7 +359,7 @@ final class OpenApiFactoryTest extends TestCase
 
         $kernelMock
             ->method('locateResource')
-            ->willReturnCallback(static function (string $path) {
+            ->willReturnCallback(static function (string $path): string {
                 return match ($path) {
                     '@TestBundle/examples/request.json' => self::EXAMPLE_REQUEST_FILE,
                     '@TestBundle/examples/request.xml' => self::EXAMPLE_REQUEST_XML_FILE,
@@ -393,7 +392,7 @@ final class OpenApiFactoryTest extends TestCase
 
         $kernelMock
             ->method('locateResource')
-            ->willReturnCallback(static function (string $path) use ($resourceMap) {
+            ->willReturnCallback(static function (string $path) use ($resourceMap): string {
                 if (isset($resourceMap[$path])) {
                     return $resourceMap[$path];
                 }

--- a/tests/bundle/ApiPlatform/OpenApiFactoryTest.php
+++ b/tests/bundle/ApiPlatform/OpenApiFactoryTest.php
@@ -33,6 +33,10 @@ final class OpenApiFactoryTest extends TestCase
     private const string EXAMPLE_RESPONSE_JSON_FILE = __DIR__ . '/Fixtures/examples/test-response.json.example';
     private const string EXAMPLE_RESPONSE_XML_FILE = __DIR__ . '/Fixtures/examples/test-response.xml.example';
 
+    private const string SCHEMA_LOGIN_REQUEST = '#/components/schemas/LoginRequest';
+    private const string EXAMPLE_REQUEST_JSON_PATH = '@TestBundle/examples/request.json';
+    private const string EXAMPLE_REQUEST_XML_PATH = '@TestBundle/examples/request.xml';
+
     private OpenApiFactory $factory;
 
     private OpenApiFactoryInterface&MockObject $decoratedFactory;
@@ -58,51 +62,17 @@ final class OpenApiFactoryTest extends TestCase
     public function testInjectsJsonRequestExampleFromFile(): void
     {
         // Given: An operation with x-ibexa-example-file in request body
-        $requestBody = new RequestBody(
-            description: 'Login request',
-            content: new ArrayObject([
-                'application/json' => [
-                    'schema' => ['$ref' => '#/components/schemas/LoginRequest'],
-                    'x-ibexa-example-file' => '@TestBundle/examples/request.json',
-                ],
-            ])
-        );
+        $requestBodyContent = [
+            'application/json' => [
+                'schema' => ['$ref' => self::SCHEMA_LOGIN_REQUEST],
+                'x-ibexa-example-file' => self::EXAMPLE_REQUEST_JSON_PATH,
+            ],
+        ];
 
-        $operation = new Operation(
-            requestBody: $requestBody,
-            responses: [
-                '200' => ['description' => 'Success'],
-            ]
-        );
-
-        $paths = new Paths();
-        $paths->addPath('/test', new PathItem(post: $operation));
-
-        $openApi = new OpenApi(
-            info: new Info(title: 'Test API', version: '1.0'),
-            servers: [],
-            paths: $paths
-        );
-
-        $this->decoratedFactory
-            ->expects(self::once())
-            ->method('__invoke')
-            ->willReturn($openApi);
-
-        // When: Factory processes the OpenAPI spec
-        $result = ($this->factory)([]);
+        $result = $this->processOpenApiWithRequestBody($requestBodyContent, $this->factory);
 
         // Then: The request example is injected from file
-        $processedPath = $result->getPaths()->getPath('/test');
-        self::assertNotNull($processedPath);
-        $processedOperation = $processedPath->getPost();
-        self::assertNotNull($processedOperation);
-        $processedRequestBody = $processedOperation->getRequestBody();
-
-        self::assertNotNull($processedRequestBody);
-        $content = $processedRequestBody->getContent();
-        self::assertNotNull($content);
-
+        $content = $this->getProcessedRequestBodyContent($result);
         $jsonContent = $content['application/json'];
 
         // Example should be injected
@@ -119,51 +89,17 @@ final class OpenApiFactoryTest extends TestCase
     public function testInjectsXmlRequestExampleFromFile(): void
     {
         // Given: An operation with XML request example
-        $requestBody = new RequestBody(
-            description: 'Login request',
-            content: new ArrayObject([
-                'application/xml' => [
-                    'schema' => ['$ref' => '#/components/schemas/LoginRequest'],
-                    'x-ibexa-example-file' => '@TestBundle/examples/request.xml',
-                ],
-            ])
-        );
+        $requestBodyContent = [
+            'application/xml' => [
+                'schema' => ['$ref' => self::SCHEMA_LOGIN_REQUEST],
+                'x-ibexa-example-file' => self::EXAMPLE_REQUEST_XML_PATH,
+            ],
+        ];
 
-        $operation = new Operation(
-            requestBody: $requestBody,
-            responses: [
-                '200' => ['description' => 'Success'],
-            ]
-        );
-
-        $paths = new Paths();
-        $paths->addPath('/test', new PathItem(post: $operation));
-
-        $openApi = new OpenApi(
-            info: new Info(title: 'Test API', version: '1.0'),
-            servers: [],
-            paths: $paths
-        );
-
-        $this->decoratedFactory
-            ->expects(self::once())
-            ->method('__invoke')
-            ->willReturn($openApi);
-
-        // When: Factory processes the OpenAPI spec
-        $result = ($this->factory)([]);
+        $result = $this->processOpenApiWithRequestBody($requestBodyContent, $this->factory);
 
         // Then: The XML request example is injected as string
-        $processedPath = $result->getPaths()->getPath('/test');
-        self::assertNotNull($processedPath);
-        $processedOperation = $processedPath->getPost();
-        self::assertNotNull($processedOperation);
-        $processedRequestBody = $processedOperation->getRequestBody();
-
-        self::assertNotNull($processedRequestBody);
-        $content = $processedRequestBody->getContent();
-        self::assertNotNull($content);
-
+        $content = $this->getProcessedRequestBodyContent($result);
         $xmlContent = $content['application/xml'];
 
         // Example should be injected as string
@@ -179,50 +115,21 @@ final class OpenApiFactoryTest extends TestCase
     public function testInjectsMultipleMediaTypeRequestExamples(): void
     {
         // Given: An operation with both JSON and XML request examples
-        $requestBody = new RequestBody(
-            description: 'Login request',
-            content: new ArrayObject([
-                'application/json' => [
-                    'schema' => ['$ref' => '#/components/schemas/LoginRequest'],
-                    'x-ibexa-example-file' => '@TestBundle/examples/request.json',
-                ],
-                'application/xml' => [
-                    'schema' => ['$ref' => '#/components/schemas/LoginRequest'],
-                    'x-ibexa-example-file' => '@TestBundle/examples/request.xml',
-                ],
-            ])
-        );
+        $requestBodyContent = [
+            'application/json' => [
+                'schema' => ['$ref' => self::SCHEMA_LOGIN_REQUEST],
+                'x-ibexa-example-file' => self::EXAMPLE_REQUEST_JSON_PATH,
+            ],
+            'application/xml' => [
+                'schema' => ['$ref' => self::SCHEMA_LOGIN_REQUEST],
+                'x-ibexa-example-file' => self::EXAMPLE_REQUEST_XML_PATH,
+            ],
+        ];
 
-        $operation = new Operation(
-            requestBody: $requestBody,
-            responses: [
-                '200' => ['description' => 'Success'],
-            ]
-        );
-
-        $paths = new Paths();
-        $paths->addPath('/test', new PathItem(post: $operation));
-
-        $openApi = new OpenApi(
-            info: new Info(title: 'Test API', version: '1.0'),
-            servers: [],
-            paths: $paths
-        );
-
-        $this->decoratedFactory
-            ->expects(self::once())
-            ->method('__invoke')
-            ->willReturn($openApi);
-
-        // When: Factory processes the OpenAPI spec
-        $result = ($this->factory)([]);
+        $result = $this->processOpenApiWithRequestBody($requestBodyContent, $this->factory);
 
         // Then: Both examples are injected correctly
-        $processedRequestBody = $result->getPaths()->getPath('/test')?->getPost()?->getRequestBody();
-
-        self::assertNotNull($processedRequestBody);
-        $content = $processedRequestBody->getContent();
-        self::assertNotNull($content);
+        $content = $this->getProcessedRequestBodyContent($result);
 
         // Verify JSON example
         $jsonContent = $content['application/json'];
@@ -244,43 +151,19 @@ final class OpenApiFactoryTest extends TestCase
     public function testThrowsExceptionWhenRequestExampleFileNotFound(): void
     {
         // Given: An operation with invalid request example file path
-        $requestBody = new RequestBody(
-            description: 'Login request',
-            content: new ArrayObject([
-                'application/json' => [
-                    'schema' => ['$ref' => '#/components/schemas/LoginRequest'],
-                    'x-ibexa-example-file' => '@TestBundle/examples/non-existent.json',
-                ],
-            ])
-        );
-
-        $operation = new Operation(
-            requestBody: $requestBody,
-            responses: [
-                '200' => ['description' => 'Success'],
-            ]
-        );
-
-        $paths = new Paths();
-        $paths->addPath('/test', new PathItem(post: $operation));
-
-        $openApi = new OpenApi(
-            info: new Info(title: 'Test API', version: '1.0'),
-            servers: [],
-            paths: $paths
-        );
-
-        $this->decoratedFactory
-            ->expects(self::once())
-            ->method('__invoke')
-            ->willReturn($openApi);
+        $requestBodyContent = [
+            'application/json' => [
+                'schema' => ['$ref' => self::SCHEMA_LOGIN_REQUEST],
+                'x-ibexa-example-file' => '@TestBundle/examples/non-existent.json',
+            ],
+        ];
 
         // Then: Exception is thrown for non-existent file
         $this->expectException(\InvalidArgumentException::class);
         $this->expectExceptionMessage('Unknown resource: @TestBundle/examples/non-existent.json');
 
         // When: Factory processes the OpenAPI spec
-        ($this->factory)([]);
+        $this->processOpenApiWithRequestBody($requestBodyContent, $this->factory);
     }
 
     public function testThrowsExceptionWhenRequestExampleJsonIsInvalid(): void
@@ -303,50 +186,77 @@ final class OpenApiFactoryTest extends TestCase
                 '/api/ibexa/v2'
             );
 
-            // Given: An operation with invalid JSON example file
-            $requestBody = new RequestBody(
-                description: 'Login request',
-                content: new ArrayObject([
-                    'application/json' => [
-                        'schema' => ['$ref' => '#/components/schemas/LoginRequest'],
-                        'x-ibexa-example-file' => '@TestBundle/examples/invalid.json',
-                    ],
-                ])
-            );
-
-            $operation = new Operation(
-                requestBody: $requestBody,
-                responses: [
-                    '200' => ['description' => 'Success'],
-                ]
-            );
-
-            $paths = new Paths();
-            $paths->addPath('/test', new PathItem(post: $operation));
-
-            $openApi = new OpenApi(
-                info: new Info(title: 'Test API', version: '1.0'),
-                servers: [],
-                paths: $paths
-            );
-
-            $this->decoratedFactory
-                ->expects(self::once())
-                ->method('__invoke')
-                ->willReturn($openApi);
+            $requestBodyContent = [
+                'application/json' => [
+                    'schema' => ['$ref' => self::SCHEMA_LOGIN_REQUEST],
+                    'x-ibexa-example-file' => '@TestBundle/examples/invalid.json',
+                ],
+            ];
 
             // Then: RuntimeException is thrown for invalid JSON
             $this->expectException(\RuntimeException::class);
             $this->expectExceptionMessage("Failed to parse JSON example file: {$invalidJsonFile}");
 
             // When: Factory processes the OpenAPI spec
-            $factory([]);
+            $this->processOpenApiWithRequestBody($requestBodyContent, $factory);
         } finally {
             // Cleanup
             if (file_exists($invalidJsonFile)) {
                 unlink($invalidJsonFile);
             }
         }
+    }
+
+    /**
+     * @param array<string, array<string, mixed>> $content
+     */
+    private function processOpenApiWithRequestBody(array $content, OpenApiFactory $factory): OpenApi
+    {
+        $requestBody = new RequestBody(
+            description: 'Login request',
+            content: new ArrayObject($content)
+        );
+
+        $operation = new Operation(
+            requestBody: $requestBody,
+            responses: [
+                '200' => ['description' => 'Success'],
+            ]
+        );
+
+        $paths = new Paths();
+        $paths->addPath('/test', new PathItem(post: $operation));
+
+        $openApi = new OpenApi(
+            info: new Info(title: 'Test API', version: '1.0'),
+            servers: [],
+            paths: $paths
+        );
+
+        $this->decoratedFactory
+            ->expects(self::once())
+            ->method('__invoke')
+            ->willReturn($openApi);
+
+        return ($factory)([]);
+    }
+
+    /**
+     * @return ArrayObject<string, mixed>
+     */
+    private function getProcessedRequestBodyContent(OpenApi $result): ArrayObject
+    {
+        $processedPath = $result->getPaths()->getPath('/test');
+        self::assertNotNull($processedPath);
+        $processedOperation = $processedPath->getPost();
+        self::assertNotNull($processedOperation);
+        $processedRequestBody = $processedOperation->getRequestBody();
+
+        self::assertNotNull($processedRequestBody);
+        $content = $processedRequestBody->getContent();
+        self::assertNotNull($content);
+
+        return $content;
     }
 
     private function getDecoratedFactoryMock(): OpenApiFactoryInterface&MockObject
@@ -362,8 +272,8 @@ final class OpenApiFactoryTest extends TestCase
             ->method('locateResource')
             ->willReturnCallback(static function (string $path): string {
                 return match ($path) {
-                    '@TestBundle/examples/request.json' => self::EXAMPLE_REQUEST_FILE,
-                    '@TestBundle/examples/request.xml' => self::EXAMPLE_REQUEST_XML_FILE,
+                    self::EXAMPLE_REQUEST_JSON_PATH => self::EXAMPLE_REQUEST_FILE,
+                    self::EXAMPLE_REQUEST_XML_PATH => self::EXAMPLE_REQUEST_XML_FILE,
                     '@TestBundle/examples/response.json' => self::EXAMPLE_RESPONSE_JSON_FILE,
                     '@TestBundle/examples/response.xml' => self::EXAMPLE_RESPONSE_XML_FILE,
                     default => throw new \InvalidArgumentException("Unknown resource: $path"),


### PR DESCRIPTION
JIRA: https://ibexa.atlassian.net/browse/IBX-10396

Current issue: request examples are not part of the REST reference, only the schema is there.

See https://doc.ibexa.co/en/5.0/api/rest_api/rest_api_reference/rest_api_reference.html#tag/Discounts/operation/api_discounts_post for an example - the schema is not that helpful when preparing a request that's more complex.

**Disclaimer: I've used Copilot when writing this, especially the tests, but I've reviewed the code manually, and verified locally that it works.  The tests are probably too verbose, but I'll leave the decision what to do with them up to you.**

Results:

[openapi_after.yaml](https://github.com/user-attachments/files/24199103/openapi_after.yaml)
[openapi_before.yaml](https://github.com/user-attachments/files/24199104/openapi_before.yaml)

In built-in Swagger:
<img width="1395" height="718" alt="Screenshot 2025-12-16 at 21 12 07" src="https://github.com/user-attachments/assets/3c4f2675-554e-4a43-a662-af622d209b60" />


<img width="1627" height="375" alt="Screenshot 2025-12-16 at 21 03 58" src="https://github.com/user-attachments/assets/9e9bc8d0-dc47-43e3-96c2-96388d2470a1" />

<img width="1668" height="558" alt="Screenshot 2025-12-16 at 21 04 28" src="https://github.com/user-attachments/assets/a3d65e33-1439-498c-8b06-1015456a0b71" />

<img width="1380" height="596" alt="Screenshot 2025-12-16 at 21 04 47" src="https://github.com/user-attachments/assets/acc742cb-9f2a-4eee-a5d2-3be56e44bf3c" />

<img width="1507" height="674" alt="Screenshot 2025-12-16 at 21 05 00" src="https://github.com/user-attachments/assets/a3dd4729-9fba-4c19-b06c-e7c8ab69f7a3" />

It also works with the buit-in Swagger doc, for both XML and JSON requests.

