### PR TITLE
JWT: The XML input and output aren't supported

### DIFF
--- a/src/bundle/Resources/api_platform/examples/user/token/jwt/POST/JWT.xml.example
+++ b/src/bundle/Resources/api_platform/examples/user/token/jwt/POST/JWT.xml.example
@@ -1,4 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<JWT media-type="application/vnd.ibexa.api.JWT+xml" token="eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpYXQiOjE2MDI4NDA3NjEsImV4cCI6MTYwMjg0NDM2MSwicm9sZXMiOlsiUk9MRV9VU0VSIl0sInVzZXJuYW1lIjoiYWRtaW4ifQ.LsmdVjad7wMwVQUo4vSftT0zHbJyArOMd23b417E2jI">
-    <token>eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpYXQiOjE2MDI4NDA3NjEsImV4cCI6MTYwMjg0NDM2MSwicm9sZXMiOlsiUk9MRV9VU0VSIl0sInVzZXJuYW1lIjoiYWRtaW4ifQ.LsmdVjad7wMwVQUo4vSftT0zHbJyArOMd23b417E2jI</token>
-</JWT>

--- a/src/bundle/Resources/api_platform/examples/user/token/jwt/POST/JWTInput.xml.example
+++ b/src/bundle/Resources/api_platform/examples/user/token/jwt/POST/JWTInput.xml.example
@@ -1,4 +1,0 @@
-<JWTInput>
-    <password>publish</password>
-    <username>admin</username>
-</JWTInput>

--- a/src/lib/Server/Controller/JWT.php
+++ b/src/lib/Server/Controller/JWT.php
@@ -25,6 +25,7 @@ use Symfony\Component\HttpFoundation\Response;
             'User Token',
         ],
         requestBody: new Model\RequestBody(
+            description: 'The JWT token input in JSON format.',
             content: new \ArrayObject([
                 'application/vnd.ibexa.api.JWTInput+json' => [
                     'schema' => [

--- a/src/lib/Server/Controller/JWT.php
+++ b/src/lib/Server/Controller/JWT.php
@@ -25,7 +25,7 @@ use Symfony\Component\HttpFoundation\Response;
             'User Token',
         ],
         requestBody: new Model\RequestBody(
-            description: 'The JWT token input in JSON format.',
+            description: 'The credentials in JWTInput JSON format.',
             content: new \ArrayObject([
                 'application/vnd.ibexa.api.JWTInput+json' => [
                     'schema' => [

--- a/src/lib/Server/Controller/JWT.php
+++ b/src/lib/Server/Controller/JWT.php
@@ -37,6 +37,7 @@ use Symfony\Component\HttpFoundation\Response;
         ),
         responses: [
             Response::HTTP_OK => [
+                'description' => 'OK - returns the JWT in JSON format.',
                 'content' => [
                     'application/vnd.ibexa.api.JWT+json' => [
                         'schema' => [

--- a/src/lib/Server/Controller/JWT.php
+++ b/src/lib/Server/Controller/JWT.php
@@ -24,34 +24,8 @@ use Symfony\Component\HttpFoundation\Response;
         tags: [
             'User Token',
         ],
-        parameters: [
-            new Model\Parameter(
-                name: 'Accept',
-                in: 'header',
-                required: true,
-                description: 'If set, the token is returned in XML or JSON format.',
-                schema: [
-                    'type' => 'string',
-                ],
-            ),
-            new Model\Parameter(
-                name: 'Content-Type',
-                in: 'header',
-                required: true,
-                description: 'The SessionInput schema encoded in XML or JSON format.',
-                schema: [
-                    'type' => 'string',
-                ],
-            ),
-        ],
         requestBody: new Model\RequestBody(
             content: new \ArrayObject([
-                'application/vnd.ibexa.api.JWTInput+xml' => [
-                    'schema' => [
-                        '$ref' => '#/components/schemas/JWTInput',
-                    ],
-                    'x-ibexa-example-file' => '@IbexaRestBundle/Resources/api_platform/examples/user/token/jwt/POST/JWTInput.xml.example',
-                ],
                 'application/vnd.ibexa.api.JWTInput+json' => [
                     'schema' => [
                         '$ref' => '#/components/schemas/JWTInputWrapper',
@@ -63,12 +37,6 @@ use Symfony\Component\HttpFoundation\Response;
         responses: [
             Response::HTTP_OK => [
                 'content' => [
-                    'application/vnd.ibexa.api.JWT+xml' => [
-                        'schema' => [
-                            '$ref' => '#/components/schemas/JWT',
-                        ],
-                        'x-ibexa-example-file' => '@IbexaRestBundle/Resources/api_platform/examples/user/token/jwt/POST/JWT.xml.example',
-                    ],
                     'application/vnd.ibexa.api.JWT+json' => [
                         'schema' => [
                             '$ref' => '#/components/schemas/JWTWrapper',


### PR DESCRIPTION
| :ticket: Issue | IBX-10444 |
|----------------|-----------|

#### Related PRs: 

- #101
- ibexa/documentation-developer#3108

#### Description:

- XML isn't supported by JWT since #101
- [IBX-10444](https://ibexa.atlassian.net/browse/IBX-10444): `Content-Type` and `Accept`headers mustn't be documented as `header` `parameters`, they're automatically documented from `requestBody.content` and `responses.<status>.content` keys

#### For QA:

On an instance, look at REST API doc at `/api/ibexa/v2/doc#/User%20Token/api_usertokenjwt_post`, and eventually click the "Try it out" button.

Before the fix:

- There are mandatory `Accept` and `Content-Type` parameter fields that are ignored.
- You can choose between XML and JSON requests and responses.
- If you test with an XML input, you get an error.
- If you test with a XML reponse, you get a JSON response anyway.

After the fix:

<img width="860" height="1417" alt="image" src="https://github.com/user-attachments/assets/7423ae3b-8029-447b-8055-09454989e56e" />

#### Documentation:

REST API Reference should be automatically fixed on next [commerce-skeleton release tagging](https://github.com/ibexa/commerce-skeleton/blob/master/.github/workflows/api_refs.yaml).

<!-- 
Before you click submit:
    - Test the solution manually
    - Provide automated test coverage
    - Confirm that target branch is set correctly
    - For new features, confirm that you have suitable access control and injection prevention
    - Run PHP CS Fixer for new PHP code (use $ composer fix-cs)
    - Run ESLint and Prettier for new JS/SCSS code (use $ yarn fix)
    - Ask for a review (ping @ibexa/php-dev or @ibexa/javascript-dev depending on the changes) 
--> 


[IBX-10444]: https://ibexa.atlassian.net/browse/IBX-10444?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ