### PR TITLE
IBX-11748: Fixed misconfiguration of ValueObjectVisitorResolverInterface

### DIFF
--- a/src/bundle/Resources/config/services.yml
+++ b/src/bundle/Resources/config/services.yml
@@ -422,7 +422,7 @@ services:
         arguments:
             $parsingDispatcher: '@Ibexa\Contracts\Rest\Input\ParsingDispatcher'
 
-    Ibexa\Contracts\Rest\Output\ValueObjectVisitorResolverInterface: '@Ibexa\Contracts\Rest\Output\ValueObjectVisitor'
+    Ibexa\Contracts\Rest\Output\ValueObjectVisitorResolverInterface: '@Ibexa\Contracts\Rest\Output\ValueObjectVisitorResolver'
 
     Ibexa\Contracts\Rest\Output\ValueObjectVisitorResolver: ~
 

--- a/tests/bundle/Functional/SessionTest.php
+++ b/tests/bundle/Functional/SessionTest.php
@@ -160,7 +160,7 @@ final class SessionTest extends TestCase
         );
         $currentSessionResponse = $this->sendHttpRequest($currentSessionRequest);
         self::assertHttpResponseCodeEquals($currentSessionResponse, 200);
-        $authenticatedData = json_decode($currentSessionResponse->getBody()->getContents(), true, JSON_THROW_ON_ERROR);
+        $authenticatedData = json_decode($currentSessionResponse->getBody()->getContents(), true, 512, JSON_THROW_ON_ERROR);
         $authenticatedUserHref = $authenticatedData['Session']['User']['_href'];
 
         // Logout
@@ -179,7 +179,7 @@ final class SessionTest extends TestCase
             )
         );
 
-        $reusedData = json_decode($reusedResponse->getBody()->getContents(), true, JSON_THROW_ON_ERROR);
+        $reusedData = json_decode($reusedResponse->getBody()->getContents(), true, 512, JSON_THROW_ON_ERROR);
         self::assertNotEquals(
             $authenticatedUserHref,
             $reusedData['Session']['User']['_href'],
@@ -244,7 +244,7 @@ final class SessionTest extends TestCase
         $this->assertHttpResponseCodeEquals($response, 200);
 
         $contents = $response->getBody()->getContents();
-        $data = json_decode($contents, true, JSON_THROW_ON_ERROR);
+        $data = json_decode($contents, true, 512, JSON_THROW_ON_ERROR);
         self::assertArrayHasKey('Session', $data);
     }
 

--- a/tests/bundle/Functional/TestCase.php
+++ b/tests/bundle/Functional/TestCase.php
@@ -352,7 +352,7 @@ XML;
         $response = $this->sendHttpRequest($request);
         self::assertHttpResponseCodeEquals($response, 201);
 
-        return json_decode($response->getBody()->getContents(), false, JSON_THROW_ON_ERROR)->Session;
+        return json_decode($response->getBody()->getContents(), false, 512, JSON_THROW_ON_ERROR)->Session;
     }
 
     /**


### PR DESCRIPTION
| :ticket: Issue | IBX-11748 |
|----------------|-----------|

<!-- 
#### Related PRs: 
- https://github.com/ibexa/core/pull/1
-->

#### Description:
Fixed the `Ibexa\Contracts\Rest\Output\ValueObjectVisitorResolverInterface` alias in `services.yaml` to point to the correct resolver.


<!-- 
Before you click submit:
    - Test the solution manually
    - Provide automated test coverage
    - Confirm that target branch is set correctly
    - For new features, confirm that you have suitable access control and injection prevention
    - Run PHP CS Fixer for new PHP code (use $ composer fix-cs)
    - Run ESLint and Prettier for new JS/SCSS code (use $ yarn fix)
    - Ask for a review (ping @ibexa/php-dev or @ibexa/javascript-dev depending on the changes) 
--> 
