### PR TITLE
Removed ibexa/polyfill-php82 dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,6 @@
         "ext-xmlwriter": "*",
         "api-platform/core": "~4.1.18",
         "ibexa/core": "~5.0.x-dev",
-        "ibexa/polyfill-php82": "^1.0",
         "ibexa/templated-uri-bundle": "^4.0",
         "lexik/jwt-authentication-bundle": "^2.8",
         "symfony/config": "^7.4",

--- a/src/contracts/Output/VisitorAdapterNormalizer.php
+++ b/src/contracts/Output/VisitorAdapterNormalizer.php
@@ -34,6 +34,8 @@ final class VisitorAdapterNormalizer implements NormalizerInterface, NormalizerA
     /**
      * @param array<string, mixed> $context
      *
+     * @return array<mixed>|bool|string|int|float|null|\ArrayObject<int|string, mixed>
+     *
      * @throws \Symfony\Component\Serializer\Exception\ExceptionInterface
      */
     public function normalize(mixed $object, ?string $format = null, array $context = []): array|bool|string|int|float|null|\ArrayObject

--- a/src/contracts/Output/VisitorAdapterNormalizer.php
+++ b/src/contracts/Output/VisitorAdapterNormalizer.php
@@ -34,7 +34,7 @@ final class VisitorAdapterNormalizer implements NormalizerInterface, NormalizerA
     /**
      * @param array<string, mixed> $context
      *
-     * @return array<mixed>|bool|string|int|float|null|\ArrayObject<int|string, mixed>
+     * @return array<mixed>|bool|string|int|float|\ArrayObject<int|string, mixed>|null
      *
      * @throws \Symfony\Component\Serializer\Exception\ExceptionInterface
      */

--- a/src/lib/Server/Input/Parser/ContentType/Query/ContentTypeQuery.php
+++ b/src/lib/Server/Input/Parser/ContentType/Query/ContentTypeQuery.php
@@ -14,7 +14,6 @@ use Ibexa\Contracts\Rest\Exceptions\Parser;
 use Ibexa\Contracts\Rest\Input\Parser\Query\Criterion\CriterionProcessorInterface;
 use Ibexa\Contracts\Rest\Input\Parser\Query\SortClause\SortClauseProcessorInterface;
 use Ibexa\Contracts\Rest\Input\ParsingDispatcher;
-use function Ibexa\PolyfillPhp82\iterator_to_array;
 use Ibexa\Rest\Input\BaseParser;
 
 /**


### PR DESCRIPTION
| :ticket: Issue | N/A |
|----------------|-----------|

<!-- 
#### Related PRs: 
- https://github.com/ibexa/core/pull/1
-->

#### Description:
This polyfill stopped being necessary since we require PHP 8.3+.

#### For QA:
<!-- Optional. Replace this comment with any necessary information needed by QA to test this Pull Request -->

#### Documentation:
<!-- Optional. Replace this comment with details helpful for writing the doc: overview, code snippets for extensibility etc. -->


<!-- 
Before you click submit:
    - Test the solution manually
    - Provide automated test coverage
    - Confirm that target branch is set correctly
    - For new features, confirm that you have suitable access control and injection prevention
    - Run PHP CS Fixer for new PHP code (use $ composer fix-cs)
    - Run ESLint and Prettier for new JS/SCSS code (use $ yarn fix)
    - Ask for a review (ping @ibexa/php-dev or @ibexa/javascript-dev depending on the changes) 
--> 
